### PR TITLE
Bug reorganizacion temas

### DIFF
--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -18,162 +18,162 @@ import java.util.stream.Collectors;
 @Entity
 public class TemaDeReunion extends Tema {
 
-  public static final String reunion_FIELD = "reunion";
-  public static final String prioridad_FIELD = "prioridad";
-  public static final String interesados_FIELD = "interesados";
-  public static final String obligatoriedad_FIELD = "obligatoriedad";
-  public static final String temaGenerador_FIELD = "temaGenerador";
-  @ManyToOne
-  private Reunion reunion;
-  private Integer prioridad;
-  @Fetch(org.hibernate.annotations.FetchMode.SELECT)
-  @ManyToMany(fetch = FetchType.EAGER)
-  private List<Usuario> interesados;
-  @Enumerated(EnumType.STRING)
-  private ObligatoriedadDeTema obligatoriedad;
-  @ManyToOne
-  private TemaGeneral temaGenerador;
+    public static final String reunion_FIELD = "reunion";
+    public static final String prioridad_FIELD = "prioridad";
+    public static final String interesados_FIELD = "interesados";
+    public static final String obligatoriedad_FIELD = "obligatoriedad";
+    public static final String temaGenerador_FIELD = "temaGenerador";
+    @ManyToOne
+    private Reunion reunion;
+    private Integer prioridad;
+    @Fetch(org.hibernate.annotations.FetchMode.SELECT)
+    @ManyToMany(fetch = FetchType.EAGER)
+    private List<Usuario> interesados;
+    @Enumerated(EnumType.STRING)
+    private ObligatoriedadDeTema obligatoriedad;
+    @ManyToOne
+    private TemaGeneral temaGenerador;
 
-  static public  TemaDeReunion create(){
-    TemaDeReunion unTema=new TemaDeReunion();
-      unTema.setObligatoriedad(ObligatoriedadDeTema.NO_OBLIGATORIO);
-      return unTema;
-  }
-
-  public static String mensajeDeErrorAlAgregarInteresado() {
-    return "No se puede agregar un interesado a un tema obligatorio";
-  }
-
-  public ObligatoriedadDeTema getObligatoriedad(){
-    return obligatoriedad;
-  }
-
-  public void setObligatoriedad(ObligatoriedadDeTema unaObligatoriedad){
-    this.obligatoriedad = unaObligatoriedad;
-  }
-
-  public Reunion getReunion() {
-    return reunion;
-  }
-
-  public void setReunion(Reunion reunion) {
-    this.reunion = reunion;
-  }
-
-  public Integer getPrioridad() {
-    return prioridad;
-  }
-
-  public void setPrioridad(Integer prioridad) {
-    this.prioridad = prioridad;
-  }
-
-  public List<Usuario> getInteresados() {
-    if (interesados == null) {
-      interesados = new ArrayList<>();
+    static public TemaDeReunion create() {
+        TemaDeReunion unTema = new TemaDeReunion();
+        unTema.setObligatoriedad(ObligatoriedadDeTema.NO_OBLIGATORIO);
+        return unTema;
     }
-    return interesados;
-  }
 
-  public void setInteresados(List<Usuario> interesados) {
-    getInteresados().clear();
-    if (interesados != null) {
-      getInteresados().addAll(interesados);
+    public static String mensajeDeErrorAlAgregarInteresado() {
+        return "No se puede agregar un interesado a un tema obligatorio";
     }
-  }
 
-  public void agregarInteresado(Usuario votante)  {
-    if(this.puedeSerVotado())
-      this.getInteresados().add(votante);
-    else
-      throw new TemaDeReunionException(mensajeDeErrorAlAgregarInteresado());
-  }
+    public ObligatoriedadDeTema getObligatoriedad() {
+        return obligatoriedad;
+    }
 
-  public void quitarInteresado(Usuario votante) {
-    this.getInteresados().remove(votante);
-  }
+    public void setObligatoriedad(ObligatoriedadDeTema unaObligatoriedad) {
+        this.obligatoriedad = unaObligatoriedad;
+    }
 
-  public int getCantidadDeVotos() {
-    return getInteresados().size();
-  }
+    public Reunion getReunion() {
+        return reunion;
+    }
+
+    public void setReunion(Reunion reunion) {
+        this.reunion = reunion;
+    }
+
+    public Integer getPrioridad() {
+        return prioridad;
+    }
+
+    public void setPrioridad(Integer prioridad) {
+        this.prioridad = prioridad;
+    }
+
+    public List<Usuario> getInteresados() {
+        if (interesados == null) {
+            interesados = new ArrayList<>();
+        }
+        return interesados;
+    }
+
+    public void setInteresados(List<Usuario> interesados) {
+        getInteresados().clear();
+        if (interesados != null) {
+            getInteresados().addAll(interesados);
+        }
+    }
+
+    public void agregarInteresado(Usuario votante) {
+        if (this.puedeSerVotado())
+            this.getInteresados().add(votante);
+        else
+            throw new TemaDeReunionException(mensajeDeErrorAlAgregarInteresado());
+    }
+
+    public void quitarInteresado(Usuario votante) {
+        this.getInteresados().remove(votante);
+    }
+
+    public int getCantidadDeVotos() {
+        return getInteresados().size();
+    }
 
 
-  public TemaDeReunion copy(){
-    TemaDeReunion copia = TemaDeReunion.create();
-    copia.setInteresados(this.getInteresados());
-    copia.setPersistenceVersion(this.getPersistenceVersion());
-    copia.setMomentoDeUltimaModificacion(this.getMomentoDeUltimaModificacion());
-    copia.setMomentoDeCreacion(this.getMomentoDeCreacion());
-    copia.setId(this.getId());
-    copia.setTitulo(this.getTitulo());
-    copia.setDescripcion(this.getDescripcion());
-    copia.setReunion(this.getReunion());
-    copia.setPrioridad(this.getPrioridad());
-    copia.setAutor(this.getAutor());
-    copia.setDuracion(this.getDuracion());
-    copia.setObligatoriedad(this.getObligatoriedad());
-    copia.setUltimoModificador(this.getUltimoModificador());
-    return copia;
-  }
+    public TemaDeReunion copy() {
+        TemaDeReunion copia = TemaDeReunion.create();
+        copia.setInteresados(this.getInteresados());
+        copia.setPersistenceVersion(this.getPersistenceVersion());
+        copia.setMomentoDeUltimaModificacion(this.getMomentoDeUltimaModificacion());
+        copia.setMomentoDeCreacion(this.getMomentoDeCreacion());
+        copia.setId(this.getId());
+        copia.setTitulo(this.getTitulo());
+        copia.setDescripcion(this.getDescripcion());
+        copia.setReunion(this.getReunion());
+        copia.setPrioridad(this.getPrioridad());
+        copia.setAutor(this.getAutor());
+        copia.setDuracion(this.getDuracion());
+        copia.setObligatoriedad(this.getObligatoriedad());
+        copia.setUltimoModificador(this.getUltimoModificador());
+        return copia;
+    }
 
 
-  public Boolean tieneMayorPrioridadQue(TemaDeReunion otroTema) {
-    Integer prioridad = getObligatoriedad().prioridad();
-    Integer otraPrioridad = otroTema.getObligatoriedad().prioridad();
+    public Boolean tieneMayorPrioridadQue(TemaDeReunion otroTema) {
+        Integer prioridad = getObligatoriedad().prioridad();
+        Integer otraPrioridad = otroTema.getObligatoriedad().prioridad();
 
-    Integer cantidadDeVotos = this.getCantidadDeVotos();
-    Integer otraCantidadDeVotos = otroTema.getCantidadDeVotos();
+        Integer cantidadDeVotos = this.getCantidadDeVotos();
+        Integer otraCantidadDeVotos = otroTema.getCantidadDeVotos();
 
-    if(prioridad.equals(otraPrioridad)
-            && getObligatoriedad().permiteRecibirVotos()
-            && cantidadDeVotos != otraCantidadDeVotos)
-      return cantidadDeVotos > otraCantidadDeVotos;
+        if (prioridad.equals(otraPrioridad)
+                && getObligatoriedad().permiteRecibirVotos()
+                && cantidadDeVotos != otraCantidadDeVotos)
+            return cantidadDeVotos > otraCantidadDeVotos;
 
-    if(otroTema.fueGeneradoPorUnTemaGeneral() ^ this.fueGeneradoPorUnTemaGeneral()) //^ -> XOR
-      return this.fueGeneradoPorUnTemaGeneral();
+        if (otroTema.fueGeneradoPorUnTemaGeneral() ^ this.fueGeneradoPorUnTemaGeneral()) //^ -> XOR
+            return this.fueGeneradoPorUnTemaGeneral();
 
-    if(prioridad.equals(otraPrioridad))
-      return otroTema.seCreoDespuesDe(this);
+        if (prioridad.equals(otraPrioridad))
+            return otroTema.seCreoDespuesDe(this);
 
-    return prioridad < otraPrioridad;
-  }
+        return prioridad < otraPrioridad;
+    }
 
-  protected Boolean seCreoDespuesDe(TemaDeReunion otroTema) {
-      return this.getMomentoDeCreacion().isAfter(otroTema.getMomentoDeCreacion());
-  }
+    protected Boolean seCreoDespuesDe(TemaDeReunion otroTema) {
+        return this.getMomentoDeCreacion().isAfter(otroTema.getMomentoDeCreacion());
+    }
 
-  public void ocultarVotosPara(Long userId) {
-      this.setInteresados(this.getInteresados()
-              .stream()
-              .filter(usuario -> usuario.getId().equals(userId))
-              .collect(Collectors.toList()));
-  }
+    public void ocultarVotosPara(Long userId) {
+        this.setInteresados(this.getInteresados()
+                .stream()
+                .filter(usuario -> usuario.getId().equals(userId))
+                .collect(Collectors.toList()));
+    }
 
-  public Boolean puedeSerVotado() {
-    return obligatoriedad.permiteRecibirVotos();
-  }
+    public Boolean puedeSerVotado() {
+        return obligatoriedad.permiteRecibirVotos();
+    }
 
-  public Boolean fueGeneradoPorUnTemaGeneral() {
-    return this.getObligatoriedad().equals(ObligatoriedadDeTema.OBLIGATORIO) && getTemaGenerador().isPresent();
-  }
+    public Boolean fueGeneradoPorUnTemaGeneral() {
+        return this.getObligatoriedad().equals(ObligatoriedadDeTema.OBLIGATORIO) && getTemaGenerador().isPresent();
+    }
 
-  public Boolean fueModificado(){
-    TemaGeneral temaGenerador=getTemaGenerador().orElseThrow(() -> new TemaDeReunionException("no tiene tema generador"));
-      return sonDiferentes(temaGenerador, Tema::getDescripcion)
-       || sonDiferentes(temaGenerador, Tema::getTitulo)
-       || sonDiferentes(temaGenerador, Tema::getDuracion)
-       || getObligatoriedad()!=ObligatoriedadDeTema.OBLIGATORIO;
-  }
+    public Boolean fueModificado() {
+        TemaGeneral temaGenerador = getTemaGenerador().orElseThrow(() -> new TemaDeReunionException("no tiene tema generador"));
+        return sonDiferentes(temaGenerador, Tema::getDescripcion)
+                || sonDiferentes(temaGenerador, Tema::getTitulo)
+                || sonDiferentes(temaGenerador, Tema::getDuracion)
+                || getObligatoriedad() != ObligatoriedadDeTema.OBLIGATORIO;
+    }
 
-  private boolean sonDiferentes(TemaGeneral temaGenerador, Function<Tema, Object> f) {
-    return !Objects.equals(f.apply(this), f.apply(temaGenerador));
-  }
+    private boolean sonDiferentes(TemaGeneral temaGenerador, Function<Tema, Object> f) {
+        return !Objects.equals(f.apply(this), f.apply(temaGenerador));
+    }
 
-  public Optional<TemaGeneral> getTemaGenerador() {
-    return Optional.ofNullable(temaGenerador);
-  }
+    public Optional<TemaGeneral> getTemaGenerador() {
+        return Optional.ofNullable(temaGenerador);
+    }
 
-  public void setTemaGenerador(TemaGeneral temaGenerador) {
-    this.temaGenerador = temaGenerador;
-  }
+    public void setTemaGenerador(TemaGeneral temaGenerador) {
+        this.temaGenerador = temaGenerador;
+    }
 }

--- a/backend/src/main/java/convention/rest/api/ReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/ReunionResource.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 import java.lang.reflect.Type;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -43,6 +44,7 @@ public class ReunionResource {
                     map(temaDeReunion ->
                             temaDeReunion.copy()).collect(Collectors.toList());
             listaDeTemasNuevos.forEach(temaDeReunion -> temaDeReunion.ocultarVotosPara(userId));
+            listaDeTemasNuevos.sort(Comparator.comparing(TemaDeReunion::getId));
             Collections.shuffle(listaDeTemasNuevos, new Random(securityContext.getUserPrincipal().hashCode())); //random turbio
             nuevaReunion.setTemasPropuestos(listaDeTemasNuevos);
         }

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -60,6 +60,7 @@ public class TemaDeReunionResource {
     }
 
     public TemaDeReunion votarTema(Usuario usuarioActual, TemaDeReunion temaDeReunion) {
+
         long cantidadDeVotos = temaDeReunion.getInteresados().stream()
                 .filter(usuario ->
                         usuario.getId().equals(usuarioActual.getId())).count();

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/ReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/ReunionTest.java
@@ -117,4 +117,21 @@ public class ReunionTest {
         Assert.assertEquals(tema4, temas.get(3));
         Assert.assertEquals(tema5, temas.get(4));
     }
+
+    @Test
+    public void test07NoSeReorganizanLosTemasPorCadaVezQueSeVota() {
+        Reunion unaReunion = Reunion.create(LocalDate.of(2017, 06, 16));
+        Usuario unUsuario = new Usuario();
+        TemaDeReunion tema1 = helper.nuevoTemaNoObligatorio();
+        TemaDeReunion tema2 = helper.nuevoTemaNoObligatorio();
+        TemaDeReunion tema3 = helper.nuevoTemaNoObligatorio();
+        List<TemaDeReunion> temasDeLaReunion = Arrays.asList(tema1, tema2, tema3);
+        unaReunion.setTemasPropuestos(temasDeLaReunion);
+
+        tema3.agregarInteresado(unUsuario);
+
+        Assert.assertEquals(tema1, unaReunion.getTemasPropuestos().get(0));
+        Assert.assertEquals(tema2, unaReunion.getTemasPropuestos().get(1));
+        Assert.assertEquals(tema3, unaReunion.getTemasPropuestos().get(2));
+    }
 }

--- a/frontend/app/components/text-area.js
+++ b/frontend/app/components/text-area.js
@@ -6,8 +6,9 @@ export default Ember.Component.extend({
   willRender() {
     this._super(...arguments);
     let value = this.get('value');
-    if(value===undefined)
+    if (value === undefined) {
       this.set('value', "");
+    }
   }
 
 });

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -8,7 +8,6 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
 
   esObligatorio: false,
   mostrarObligatorios: false,
-  errorVotacion: false,
 
   reunion: Ember.computed('model.reunion', function () {
     return this.get('model.reunion');
@@ -224,8 +223,6 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
     tema.agregarInteresado(this._idDeUsuarioActual());
     this.temaService().votarTema(tema.id).then(() =>{
       this._recargarReunion();
-    }, () => {
-      this.set('errorVotacion', true);
     });
   },
 
@@ -233,8 +230,6 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
     tema.quitarInteresado(this._idDeUsuarioActual());
     this.temaService().quitarVotoTema(tema.id).then(() => {
       this._recargarReunion();
-    }, () => {
-      this.set('errorVotacion', true);
     });
   },
 

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -8,6 +8,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
 
   esObligatorio: false,
   mostrarObligatorios: false,
+  errorVotacion: false,
 
   reunion: Ember.computed('model.reunion', function () {
     return this.get('model.reunion');
@@ -221,17 +222,17 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
 
   _votarPorTema(tema){
     tema.agregarInteresado(this._idDeUsuarioActual());
-    this.temaService().votarTema(tema.id).then((response) =>{
-    }, (error) => {
-      console.log("error");
+    this.temaService().votarTema(tema.id).then(() =>{
+    }, () => {
+      this.set('errorVotacion', true);
     });
   },
 
   _quitarVotoDeTema(tema){
     tema.quitarInteresado(this._idDeUsuarioActual());
-    this.temaService().quitarVotoTema(tema.id).then((response) => {
-    }, (error) => {
-      console.log("error");
+    this.temaService().quitarVotoTema(tema.id).then(() => {
+    }, () => {
+      this.set('errorVotacion', true);
     });
   },
 

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -61,7 +61,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
     return this.get('votosRestantes') === 0;
   }),
   puedeCerrar: Ember.computed('terminoDeVotar','reunion.status',function(){
-    return this.get('terminoDeVotar') && !(this.get('reunion.status')==='CON_MINUTA');
+    return this.get('terminoDeVotar') && this.get('reunion.status') !=='CON_MINUTA';
 }),
   actions: {
     sumarVoto(tema){
@@ -221,16 +221,12 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
 
   _votarPorTema(tema){
     tema.agregarInteresado(this._idDeUsuarioActual());
-    this.temaService().votarTema(tema.id).then(() => {
-      this._recargarReunion();
-    });
+    this.temaService().votarTema(tema.id);
   },
 
   _quitarVotoDeTema(tema){
     tema.quitarInteresado(this._idDeUsuarioActual());
-    this.temaService().quitarVotoTema(tema.id).then(() => {
-      this._recargarReunion();
-    });
+    this.temaService().quitarVotoTema(tema.id);
   },
 
   _usarInstanciasDeTemas(reunion, usuarioActual){

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -221,12 +221,18 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
 
   _votarPorTema(tema){
     tema.agregarInteresado(this._idDeUsuarioActual());
-    this.temaService().votarTema(tema.id);
+    this.temaService().votarTema(tema.id).then((response) =>{
+    }, (error) => {
+      console.log("error");
+    });
   },
 
   _quitarVotoDeTema(tema){
     tema.quitarInteresado(this._idDeUsuarioActual());
-    this.temaService().quitarVotoTema(tema.id);
+    this.temaService().quitarVotoTema(tema.id).then((response) => {
+    }, (error) => {
+      console.log("error");
+    });
   },
 
   _usarInstanciasDeTemas(reunion, usuarioActual){

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -223,6 +223,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
   _votarPorTema(tema){
     tema.agregarInteresado(this._idDeUsuarioActual());
     this.temaService().votarTema(tema.id).then(() =>{
+      this._recargarReunion();
     }, () => {
       this.set('errorVotacion', true);
     });
@@ -231,6 +232,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
   _quitarVotoDeTema(tema){
     tema.quitarInteresado(this._idDeUsuarioActual());
     this.temaService().quitarVotoTema(tema.id).then(() => {
+      this._recargarReunion();
     }, () => {
       this.set('errorVotacion', true);
     });

--- a/frontend/app/controllers/reuniones/list.js
+++ b/frontend/app/controllers/reuniones/list.js
@@ -28,7 +28,7 @@ export default Ember.Controller.extend(ReunionServiceInjected,MinutaServiceInjec
   }),
   reunionMinuteada:Ember.computed('reunionSeleccionada','minuta',function(){
 
-    return !(this.get('reunionSeleccionada.status')==='CON_MINUTA');
+    return this.get('reunionSeleccionada.status') !=='CON_MINUTA';
 }),
   temasEstimados: Ember.computed('duracionDeReunion',function(){
 

--- a/frontend/app/templates/reuniones/edit.hbs
+++ b/frontend/app/templates/reuniones/edit.hbs
@@ -19,10 +19,6 @@
 
 <div class="row">
 
-  {{#if errorVotacion}}
-    <p>Hubo un error</p>
-  {{/if}}
-
   <table class="bordered highlight col s12">
     <thead>
       <tr>

--- a/frontend/app/templates/reuniones/edit.hbs
+++ b/frontend/app/templates/reuniones/edit.hbs
@@ -19,6 +19,10 @@
 
 <div class="row">
 
+  {{#if errorVotacion}}
+    <p>Hubo un error</p>
+  {{/if}}
+
   <table class="bordered highlight col s12">
     <thead>
       <tr>

--- a/frontend/app/templates/reuniones/edit.hbs
+++ b/frontend/app/templates/reuniones/edit.hbs
@@ -18,6 +18,7 @@
 </div>
 
 <div class="row">
+
   <table class="bordered highlight col s12">
     <thead>
       <tr>

--- a/frontend/tests/helpers/start-app.js
+++ b/frontend/tests/helpers/start-app.js
@@ -12,6 +12,6 @@ export default function startApp(attrs) {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();
-})
+  });
   return application;
 }


### PR DESCRIPTION
-El problema estaba en que a pesar de usar random con la misma semilla siempre, esto no era determinístico ya que la lista de temas de la reunión venía desde otro lugar en un orden distinto cada vez por alguna razón que desconozco. Al parecer el orden en el que va a ordenar la lista no depende sólo de la semilla que recibe el random si no también del orden desde el que ya comienza la misma.
Es por esto que la ordeno antes de modificarla aleatoriamente con el random, para que el orden que decida el shuffle siempre sea el mismo.

-Se me escapó un CTRL + ALT + L en un archivo y además saqué algún que otro warning.