### PR TITLE
Acceso a stg

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,9 +12,6 @@
       },
     "ENVIRONMENT":{
       "required":"true"
-    },
-    "ENVIROMENT":{
-      "required":"true"
     }
   },
   "buildpacks": [

--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
       "description": "Para que buildee bien",
         "value": "clean package"
       },
-    "ENVIRONMENT":{
+    "ENVIROMENT":{
       "required":"true"
     }
   },

--- a/app.json
+++ b/app.json
@@ -9,7 +9,13 @@
     "MAVEN_CUSTOM_GOALS": {
       "description": "Para que buildee bien",
         "value": "clean package"
-      }
+      },
+    "ENVIRONMENT":{
+      "required":"true"
+    },
+    "ENVIROMENT":{
+      "required":"true"
+    }
   },
   "buildpacks": [
     {

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -215,7 +215,16 @@
       <artifactId>flyway-core</artifactId>
       <version>5.0.7</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.0-beta.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.0-beta.5</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuConfig.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuConfig.java
@@ -16,12 +16,8 @@ import java.util.function.Function;
  * This type represents the configuration used to run in heroku with values taken from the OS environment
  * Created by kfgodel on 13/03/16.
  */
-public class HerokuConfig implements TemasConfiguration {
+public abstract class HerokuConfig implements TemasConfiguration {
   private DependencyInjector injector= DependencyInjectorImpl.create();
-  public static HerokuConfig create() {
-    HerokuConfig config = new HerokuConfig();
-    return config;
-  }
 
   @Override
   public DbCoordinates getDatabaseCoordinates() {
@@ -43,9 +39,7 @@ public class HerokuConfig implements TemasConfiguration {
   }
 
   @Override
-  public Function<WebCredential, Optional<Object>> autenticador() {
-    return BackofficeCallbackAuthenticatorForRootsOnly.create(getInjector());
-  }
+  public abstract Function<WebCredential, Optional<Object>> autenticador();
 
   @Override
   public DependencyInjector getInjector() {

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
@@ -19,11 +19,11 @@ public class HerokuPriorityConfigSelector implements ConfigurationSelector {
 
   @Override
   public TemasConfiguration selectConfig() {
-    if ("PROD".equals(System.getenv("ENVIRONMENT"))) {
+    if ("PROD".equals(System.getenv("ENVIROMENT"))) {
       LOG.info("Using Heroku configuration");
       return HerokuProductionConfig.create();
     }
-    if("STG".equals(System.getenv("ENVIRONMENT"))){
+    if("STG".equals(System.getenv("ENVIROMENT"))){
       LOG.info("Using staging configuration");
       return HerokuStagingConfig.create();
     }

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
@@ -19,10 +19,11 @@ public class HerokuPriorityConfigSelector implements ConfigurationSelector {
 
   @Override
   public TemasConfiguration selectConfig() {
-    if ("PROD".equals(System.getenv("ENVIROMENT"))) {
+    if ("PROD".equals(System.getenv("ENVIRONMENT"))) {
       LOG.info("Using Heroku configuration");
       return HerokuProductionConfig.create();
-    }else if("STG".equals(System.getenv("ENVIROMENT"))){
+    }
+    if("STG".equals(System.getenv("ENVIRONMENT"))){
       LOG.info("Using staging configuration");
       return HerokuStagingConfig.create();
     }

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
@@ -21,7 +21,10 @@ public class HerokuPriorityConfigSelector implements ConfigurationSelector {
   public TemasConfiguration selectConfig() {
     if ("PROD".equals(System.getenv("ENVIROMENT"))) {
       LOG.info("Using Heroku configuration");
-      return HerokuConfig.create();
+      return HerokuProductionConfig.create();
+    }else if("STG".equals(System.getenv("ENVIROMENT"))){
+      LOG.info("Using staging configuration");
+      return HerokuStagingConfig.create();
     }
     LOG.info("Using development configuration");
     return DevelopmentConfig.create();

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
@@ -19,7 +19,7 @@ public class HerokuPriorityConfigSelector implements ConfigurationSelector {
 
   @Override
   public TemasConfiguration selectConfig() {
-    if (System.getenv("PORT") != null && System.getenv("DATABASE_URL") != null) {
+    if ("PROD".equals(System.getenv("ENVIROMENT"))) {
       LOG.info("Using Heroku configuration");
       return HerokuConfig.create();
     }

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuPriorityConfigSelector.java
@@ -1,5 +1,6 @@
 package ar.com.kfgodel.temas.config;
 
+import ar.com.kfgodel.temas.config.environments.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,7 +12,6 @@ import org.slf4j.LoggerFactory;
 public class HerokuPriorityConfigSelector implements ConfigurationSelector {
   public static Logger LOG = LoggerFactory.getLogger(HerokuPriorityConfigSelector.class);
 
-
   public static HerokuPriorityConfigSelector create() {
     HerokuPriorityConfigSelector selector = new HerokuPriorityConfigSelector();
     return selector;
@@ -19,15 +19,6 @@ public class HerokuPriorityConfigSelector implements ConfigurationSelector {
 
   @Override
   public TemasConfiguration selectConfig() {
-    if ("PROD".equals(System.getenv("ENVIROMENT"))) {
-      LOG.info("Using Heroku configuration");
-      return HerokuProductionConfig.create();
-    }
-    if("STG".equals(System.getenv("ENVIROMENT"))){
-      LOG.info("Using staging configuration");
-      return HerokuStagingConfig.create();
-    }
-    LOG.info("Using development configuration");
-    return DevelopmentConfig.create();
+    return Environment.toHandle(System.getenv("ENVIROMENT")).getConfig(LOG);
   }
 }

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuProductionConfig.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuProductionConfig.java
@@ -1,0 +1,18 @@
+package ar.com.kfgodel.temas.config;
+
+import ar.com.kfgodel.temas.application.auth.BackofficeCallbackAuthenticatorForRootsOnly;
+import ar.com.kfgodel.webbyconvention.api.auth.WebCredential;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public class HerokuProductionConfig extends HerokuConfig{
+    public static HerokuConfig create() {
+        HerokuConfig config = new HerokuProductionConfig();
+        return config;
+    }
+
+    public Function<WebCredential, Optional<Object>> autenticador() {
+        return BackofficeCallbackAuthenticatorForRootsOnly.create(getInjector());
+    }
+}

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuStagingConfig.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/HerokuStagingConfig.java
@@ -1,0 +1,22 @@
+package ar.com.kfgodel.temas.config;
+
+import ar.com.kfgodel.temas.application.auth.BackofficeCallbackAuthenticatorForAll;
+import ar.com.kfgodel.temas.application.auth.BackofficeCallbackAuthenticatorForRootsOnly;
+import ar.com.kfgodel.webbyconvention.api.auth.WebCredential;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public class HerokuStagingConfig extends HerokuConfig{
+
+    public static HerokuConfig create() {
+        HerokuConfig config = new HerokuStagingConfig();
+        return config;
+    }
+
+    @Override
+    public Function<WebCredential, Optional<Object>> autenticador() {
+        return BackofficeCallbackAuthenticatorForAll.create(getInjector());
+    }
+
+}

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Development.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Development.java
@@ -1,0 +1,19 @@
+package ar.com.kfgodel.temas.config.environments;
+
+import ar.com.kfgodel.temas.config.DevelopmentConfig;
+import ar.com.kfgodel.temas.config.TemasConfiguration;
+import org.slf4j.Logger;
+
+public class Development extends Environment {
+
+    @Override
+    public TemasConfiguration getConfig(Logger log) {
+        log.info("Using development configuration");
+        return DevelopmentConfig.create();
+    }
+
+    @Override
+    protected boolean canHandle(String enviroment) {
+        return false;
+    }
+}

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Environment.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Environment.java
@@ -1,0 +1,21 @@
+package ar.com.kfgodel.temas.config.environments;
+
+import ar.com.kfgodel.temas.config.TemasConfiguration;
+import org.slf4j.Logger;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class Environment {
+
+    private static List<Environment> enviroments = Arrays.asList(new Development(), new Staging(), new Production());
+
+    public static Environment toHandle(String enviroment) {
+        return enviroments.stream().filter(env -> env.canHandle(enviroment))
+                .findFirst().orElse(new Development());
+    }
+
+    public abstract TemasConfiguration getConfig(Logger log);
+
+    protected abstract boolean canHandle(String enviroment);
+}

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Production.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Production.java
@@ -1,0 +1,19 @@
+package ar.com.kfgodel.temas.config.environments;
+
+import ar.com.kfgodel.temas.config.HerokuProductionConfig;
+import ar.com.kfgodel.temas.config.TemasConfiguration;
+import org.slf4j.Logger;
+
+public class Production extends Environment {
+    @Override
+    public TemasConfiguration getConfig(Logger log) {
+        log.info("Using Heroku-Production configuration");
+        return HerokuProductionConfig.create();
+    }
+
+    @Override
+    protected boolean canHandle(String environment) {
+        return "PROD".equals(environment);
+    }
+
+}

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Production.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Production.java
@@ -5,6 +5,8 @@ import ar.com.kfgodel.temas.config.TemasConfiguration;
 import org.slf4j.Logger;
 
 public class Production extends Environment {
+    private String environmentVariable = "PROD";
+
     @Override
     public TemasConfiguration getConfig(Logger log) {
         log.info("Using Heroku-Production configuration");
@@ -13,7 +15,7 @@ public class Production extends Environment {
 
     @Override
     protected boolean canHandle(String environment) {
-        return "PROD".equals(environment);
+        return environmentVariable.equals(environment);
     }
 
 }

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Staging.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Staging.java
@@ -1,0 +1,18 @@
+package ar.com.kfgodel.temas.config.environments;
+
+import ar.com.kfgodel.temas.config.HerokuStagingConfig;
+import ar.com.kfgodel.temas.config.TemasConfiguration;
+import org.slf4j.Logger;
+
+public class Staging extends Environment {
+    @Override
+    public TemasConfiguration getConfig(Logger log) {
+        log.info("Using Heroku-Staging configuration");
+        return HerokuStagingConfig.create();
+    }
+
+    @Override
+    protected boolean canHandle(String enviroment) {
+        return "STG".equals(enviroment);
+    }
+}

--- a/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Staging.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/config/environments/Staging.java
@@ -5,6 +5,9 @@ import ar.com.kfgodel.temas.config.TemasConfiguration;
 import org.slf4j.Logger;
 
 public class Staging extends Environment {
+
+    private String environmentVariable = "STG";
+
     @Override
     public TemasConfiguration getConfig(Logger log) {
         log.info("Using Heroku-Staging configuration");
@@ -13,6 +16,6 @@ public class Staging extends Environment {
 
     @Override
     protected boolean canHandle(String enviroment) {
-        return "STG".equals(enviroment);
+        return environmentVariable.equals(enviroment);
     }
 }

--- a/backend/src/main/resources/buildNumber.properties
+++ b/backend/src/main/resources/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Tue May 15 15:12:21 ART 2018
-buildNumber=34
+#Thu Aug 23 10:27:04 ART 2018
+buildNumber=35

--- a/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EnviromentConfigTest {
 
     private HerokuPriorityConfigSelector configSelector;
-    private String variableName = "ENVIROMENT";
+    private String environmentVariable = "ENVIROMENT";
 
     @Before
     public void setUp(){
@@ -24,19 +24,19 @@ public class EnviromentConfigTest {
 
     @Test
     public void siElEnviromentEsDevelopmentLaConfiguracionEsDevelopment(){
-        PowerMockito.when(System.getenv(variableName)).thenReturn("DEV");
+        PowerMockito.when(System.getenv(environmentVariable)).thenReturn("DEV");
         assertThat(configSelector.selectConfig()).isInstanceOf(DevelopmentConfig.class);
     }
 
     @Test
     public void siElEnviromentEsProduccionLaConfiguracionEsHerokuConAccesoParaRoots(){
-        PowerMockito.when(System.getenv(variableName)).thenReturn("PROD");
+        PowerMockito.when(System.getenv(environmentVariable)).thenReturn("PROD");
         assertThat(configSelector.selectConfig()).isInstanceOf(HerokuConfig.class);
     }
 
     @Test
     public void siElEnviromentEsStaginLaConfiguracionEsHerokuConAccesoParaTodos(){
-        PowerMockito.when(System.getenv(variableName)).thenReturn("STG");
+        PowerMockito.when(System.getenv(environmentVariable)).thenReturn("STG");
         assertThat(configSelector.selectConfig()).isInstanceOf(HerokuStagingConfig.class);
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
@@ -1,0 +1,41 @@
+package ar.com.kfgodel.temas.config;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({HerokuPriorityConfigSelector.class})
+public class EnviromentConfigTest {
+
+    private HerokuPriorityConfigSelector configSelector;
+
+    @Before
+    public void setUp(){
+        configSelector = HerokuPriorityConfigSelector.create();
+        PowerMockito.mockStatic(System.class);
+    }
+
+    @Test
+    public void siElEnviromentEsDevelopmentLaConfiguracionEsDevelopment(){
+        PowerMockito.when(System.getenv("ENVIROMENT")).thenReturn("DEV");
+        assertThat(configSelector.selectConfig()).isInstanceOf(DevelopmentConfig.class);
+    }
+
+    @Test
+    public void siElEnviromentEsProduccionLaConfiguracionEsHerokuConAccesoParaRoots(){
+        PowerMockito.when(System.getenv("ENVIROMENT")).thenReturn("PROD");
+        assertThat(configSelector.selectConfig()).isInstanceOf(HerokuConfig.class);
+    }
+
+    @Test
+    public void siElEnviromentEsStaginLaConfiguracionEsHerokuConAccesoParaTodos(){
+        PowerMockito.when(System.getenv("ENVIROMENT")).thenReturn("STG");
+        assertThat(configSelector.selectConfig()).isInstanceOf(HerokuStagingConfig.class);
+    }
+}

--- a/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EnviromentConfigTest {
 
     private HerokuPriorityConfigSelector configSelector;
+    private String variableName = "ENVIRONMENT";
 
     @Before
     public void setUp(){
@@ -23,19 +24,19 @@ public class EnviromentConfigTest {
 
     @Test
     public void siElEnviromentEsDevelopmentLaConfiguracionEsDevelopment(){
-        PowerMockito.when(System.getenv("ENVIRONMENT")).thenReturn("DEV");
+        PowerMockito.when(System.getenv(variableName)).thenReturn("DEV");
         assertThat(configSelector.selectConfig()).isInstanceOf(DevelopmentConfig.class);
     }
 
     @Test
     public void siElEnviromentEsProduccionLaConfiguracionEsHerokuConAccesoParaRoots(){
-        PowerMockito.when(System.getenv("ENVIRONMENT")).thenReturn("PROD");
+        PowerMockito.when(System.getenv(variableName)).thenReturn("PROD");
         assertThat(configSelector.selectConfig()).isInstanceOf(HerokuConfig.class);
     }
 
     @Test
     public void siElEnviromentEsStaginLaConfiguracionEsHerokuConAccesoParaTodos(){
-        PowerMockito.when(System.getenv("ENVIROMENT")).thenReturn("STG");
+        PowerMockito.when(System.getenv(variableName)).thenReturn("STG");
         assertThat(configSelector.selectConfig()).isInstanceOf(HerokuStagingConfig.class);
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
@@ -23,13 +23,13 @@ public class EnviromentConfigTest {
 
     @Test
     public void siElEnviromentEsDevelopmentLaConfiguracionEsDevelopment(){
-        PowerMockito.when(System.getenv("ENVIROMENT")).thenReturn("DEV");
+        PowerMockito.when(System.getenv("ENVIRONMENT")).thenReturn("DEV");
         assertThat(configSelector.selectConfig()).isInstanceOf(DevelopmentConfig.class);
     }
 
     @Test
     public void siElEnviromentEsProduccionLaConfiguracionEsHerokuConAccesoParaRoots(){
-        PowerMockito.when(System.getenv("ENVIROMENT")).thenReturn("PROD");
+        PowerMockito.when(System.getenv("ENVIRONMENT")).thenReturn("PROD");
         assertThat(configSelector.selectConfig()).isInstanceOf(HerokuConfig.class);
     }
 

--- a/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/config/EnviromentConfigTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EnviromentConfigTest {
 
     private HerokuPriorityConfigSelector configSelector;
-    private String variableName = "ENVIRONMENT";
+    private String variableName = "ENVIROMENT";
 
     @Before
     public void setUp(){


### PR DESCRIPTION
- CanHandle para sacar los if del config selector. 
- Tests de seleccion de configuración según variable de ambiente
- Configuracion de variable de ambiente en app.json

Queda pendiente: 
- Crear objetos distintos para la bd y el autenticador, para poder armar distintas configuraciones desde
los "Environments", con el fin de que sea más facil agregar un nuevo ambiente. Había hablado con Joaco que un refactor de este tipo quede para el final del sprint en caso de que quede tiempo o charlar en la próxima planning si se quiere hacer. 
