### PR TITLE
Pequeños arreglos visuales

### DIFF
--- a/backend/src/main/java/convention/persistent/ActionItem.java
+++ b/backend/src/main/java/convention/persistent/ActionItem.java
@@ -34,7 +34,7 @@ public class ActionItem  extends PersistableSupport {
     private Boolean fueNotificado;
 
     public ActionItem() {
-        this.fueNotificado =true;
+        this.fueNotificado = false;
         this.addObserver(MailerObserver.create());
     }
 

--- a/backend/src/main/java/convention/persistent/ActionItem.java
+++ b/backend/src/main/java/convention/persistent/ActionItem.java
@@ -34,7 +34,7 @@ public class ActionItem  extends PersistableSupport {
     private Boolean fueNotificado;
 
     public ActionItem() {
-        this.fueNotificado = false;
+        this.fueNotificado = true;
         this.addObserver(MailerObserver.create());
     }
 

--- a/frontend/app/components/opcion-header.js
+++ b/frontend/app/components/opcion-header.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   classNames: ['tab'],
 
   marcable: Ember.computed('route', function () {
-    if (window.location.pathname.replace(/\d/g, "") == this.route) {
+    if (window.location.pathname.replace(/\d/g, "") === this.route) {
       return 'bold';
     }
   })

--- a/frontend/app/concepts/tema.js
+++ b/frontend/app/concepts/tema.js
@@ -27,7 +27,7 @@ export default Ember.Object.extend({
   }),
 
   noTieneVotos: Ember.computed('noTieneVotos', 'cantidadVotosPropios', function () {
-    return this.get('cantidadVotosPropios') == 0;
+    return this.get('cantidadVotosPropios') === 0;
   }),
 
   cantidadVotosPropios: Ember.computed('idsDeInteresados.[]', 'usuarioActual', function () {

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -123,7 +123,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
     }),
   puedeCerrar:
     Ember.computed('terminoDeVotar', 'reunion.status', function () {
-      return this.get('terminoDeVotar') && !(this.get('reunion.status') === 'CON_MINUTA');
+      return this.get('terminoDeVotar') && this.get('reunion.status') !== 'CON_MINUTA';
     }),
 
   actions:
@@ -377,7 +377,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
   _cerrarReunion() {
     var reunion = this.get('reunion');
     this.reunionService().cerrarReunion(reunion)
-      .then((cerrada) => {
+      .then(() => {
         this.navigator().navigateToVerMinuta(reunion.id);
       });
   },

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -197,4 +197,16 @@ h6 {
   display: contents;
 }
 
+div input[type=text]:focus:not([readonly]) + label{
+  color: grey;
+}
+
+.ember-power-select-trigger:focus, div .ember-power-select-trigger{
+  border-bottom: 1px solid $primary-color;
+}
+
+img {
+  max-width: 100%;
+}
+
 @import "ember-power-select";

--- a/frontend/app/styles/minuta.css
+++ b/frontend/app/styles/minuta.css
@@ -116,6 +116,5 @@
 }
 
 .descripcion-minuta{
-  text-align: justify;
   max-width: 80vh !important;
 }

--- a/frontend/app/templates/components/view-minuta-tema.hbs
+++ b/frontend/app/templates/components/view-minuta-tema.hbs
@@ -24,9 +24,11 @@
           }}
         </p>
       {{/if}}
+      <div class="ml-20">
       {{#if editable}}
         {{switch-tratado tema=temaDeMinuta}}
       {{/if}}
+      </div>
     </div>
 
     {{#if expandido}}

--- a/frontend/app/templates/reuniones/list.hbs
+++ b/frontend/app/templates/reuniones/list.hbs
@@ -16,7 +16,7 @@
 
     <div class="col s8">
       <div class="card">
-        <a class="btn-floating waves-effect waves-light red right"  {{action 'cerrarDetalle'}}><i class="material-icons ">close</i></a>
+        <a class="btn-floating waves-effect waves-light purple right m-5"  {{action 'cerrarDetalle'}}><i class="material-icons ">close</i></a>
 
         <div class="card-content">
           <span class="card-title">ID: {{reunionSeleccionada.id}} - Fecha {{reunionSeleccionada.fecha}} </span>
@@ -72,7 +72,7 @@
   {{/if}}
 </div>
 <div class="row">
-  <a class="btn-floating btn-large waves-effect waves-light red right" {{action 'crearReunion'}}><i
+  <a class="btn-floating btn-large waves-effect waves-light purple right" {{action 'crearReunion'}}><i
     class="material-icons">add</i></a>
   </div>
 


### PR DESCRIPTION
- Las imagenes grandes no desbordan todo, ya que se ajustan al tamaño máximo del contenedor en el que están
- El texto en la descripción de la edición de la minuta ya no esta justificado 
- Los botones de la lista de reuniones ahora son violeta y no rojos
- Margenes en lugares donde faltaban
- Generalizar colores de text box y selectores
- Se saca algún que otro warning