### PR TITLE
Link a minuta

### DIFF
--- a/backend/src/main/java/ar/com/kfgodel/temas/filters/MinutaDeReunion.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/filters/MinutaDeReunion.java
@@ -15,7 +15,7 @@ public class MinutaDeReunion implements TransactionOperation<Nary<Minuta>> {
     private static Long reunionId;
 
     public static MinutaDeReunion create(Long reunionId){
-            MinutaDeReunion minutaDeReunion=new MinutaDeReunion();
+        MinutaDeReunion minutaDeReunion = new MinutaDeReunion();
         MinutaDeReunion.reunionId = reunionId;
         return minutaDeReunion;
     }

--- a/backend/src/main/java/ar/com/kfgodel/temas/filters/reuniones/UltimaReunion.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/filters/reuniones/UltimaReunion.java
@@ -1,0 +1,32 @@
+package ar.com.kfgodel.temas.filters.reuniones;
+
+import ar.com.kfgodel.nary.api.Nary;
+import ar.com.kfgodel.orm.api.TransactionContext;
+import ar.com.kfgodel.orm.api.operations.TransactionOperation;
+import com.querydsl.jpa.hibernate.HibernateQueryFactory;
+import convention.persistent.QReunion;
+import convention.persistent.Reunion;
+import convention.persistent.StatusDeReunion;
+
+public class UltimaReunion implements TransactionOperation<Nary<Reunion>> {
+
+  public static UltimaReunion create() {
+    UltimaReunion filtro = new UltimaReunion();
+    return filtro;
+  }
+
+  @Override
+  public Nary<Reunion> applyWithTransactionOn(TransactionContext transactionContext) {
+    HibernateQueryFactory queryFactory = new HibernateQueryFactory(transactionContext.getSession());
+
+    QReunion reunion = QReunion.reunion;
+
+    Reunion ultimaReunion = queryFactory.selectFrom(reunion)
+      .where(reunion.status.eq(StatusDeReunion.CON_MINUTA))
+      .orderBy(reunion.fecha.desc())
+      .limit(1)
+      .fetchOne();
+
+    return Nary.ofNullable(ultimaReunion);
+  }
+}

--- a/backend/src/main/java/convention/rest/api/MinutaResource.java
+++ b/backend/src/main/java/convention/rest/api/MinutaResource.java
@@ -25,9 +25,9 @@ public class MinutaResource{
     @GET
     @Path("reunion/{reunionId}")
     public MinutaTo getParaReunion(@PathParam("reunionId") Long id ){
-         Minuta minuta = minutaService.getFromReunion(id);
+        Minuta minuta = minutaService.getFromReunion(id);
         minutaService.update(minuta);
-        return  getResourceHelper().convertir(minuta, MinutaTo.class);
+        return getResourceHelper().convertir(minuta, MinutaTo.class);
     }
 
     @PUT
@@ -38,6 +38,13 @@ public class MinutaResource{
         minuta.setMinuteador(ultimoMinuteador);
         Minuta minutaActualizada = minutaService.update(minuta);
         return  getResourceHelper().convertir(minutaActualizada, MinutaTo.class);
+    }
+
+    @GET
+    @Path("/ultimaMinuta")
+    public MinutaTo getUltimaMinuta(){
+        Minuta minuta = minutaService.getUltimaMinuta();
+        return getResourceHelper().convertir(minuta, MinutaTo.class);
     }
 
     public static MinutaResource create(DependencyInjector appInjector) {

--- a/backend/src/main/java/convention/services/MinutaService.java
+++ b/backend/src/main/java/convention/services/MinutaService.java
@@ -14,6 +14,7 @@ import java.util.List;
  * Created by sandro on 07/07/17.
  */
 public class MinutaService extends Service<Minuta> {
+
     @Inject
     ReunionService reunionService;
 
@@ -36,8 +37,12 @@ public class MinutaService extends Service<Minuta> {
                                 ).get();
 
     }
+
     public List<Minuta> getAll() {
         return getAll(FindAll.of(Minuta.class));
     }
 
+    public Minuta getUltimaMinuta() {
+      return this.getFromReunion(reunionService.getUltimaReunion().getId());
+    }
 }

--- a/backend/src/main/java/convention/services/ReunionService.java
+++ b/backend/src/main/java/convention/services/ReunionService.java
@@ -4,6 +4,7 @@ import ar.com.kfgodel.temas.acciones.CrearProximaReunion;
 import ar.com.kfgodel.temas.acciones.UsarReunionExistente;
 import ar.com.kfgodel.temas.filters.reuniones.AllReunionesUltimaPrimero;
 import ar.com.kfgodel.temas.filters.reuniones.ProximaReunion;
+import ar.com.kfgodel.temas.filters.reuniones.UltimaReunion;
 import convention.persistent.Minuta;
 import convention.persistent.Reunion;
 import convention.persistent.TemaGeneral;
@@ -16,39 +17,44 @@ import java.util.List;
  * Created by sandro on 21/06/17.
  */
 public class ReunionService extends Service<Reunion> {
-    @Inject
-    MinutaService minutaService;
+  @Inject
+  MinutaService minutaService;
 
-    @Inject
-    TemaGeneralService temaGeneralService;
-    public ReunionService() {
-        setClasePrincipal(Reunion.class);
-    }
+  @Inject
+  TemaGeneralService temaGeneralService;
 
-    public Reunion getProxima() {
-        return createOperation()
-                .insideATransaction()
-                .applying(ProximaReunion.create())
-                .applyingResultOf((existente) ->
-                        existente.mapOptional(UsarReunionExistente::create)
-                                .orElseGet(() -> CrearProximaReunion.create(this))).get();
-    }
+  public ReunionService() {
+    setClasePrincipal(Reunion.class);
+  }
 
-    public List<Reunion> getAll() {
-        return getAll(AllReunionesUltimaPrimero.create());
-    }
+  public Reunion getProxima() {
+    return createOperation()
+        .insideATransaction()
+        .applying(ProximaReunion.create())
+        .applyingResultOf((existente) ->
+            existente.mapOptional(UsarReunionExistente::create)
+                .orElseGet(() -> CrearProximaReunion.create(this))).get();
+  }
 
-    @Override
-    public void delete(Long id) {
-        Minuta minuta = minutaService.getFromReunion(id);
-        minutaService.delete(minuta.getId());
-        super.delete(id);
-    }
+  public List<Reunion> getAll() {
+    return getAll(AllReunionesUltimaPrimero.create());
+  }
 
-    @Override
-    public Reunion save(Reunion nuevaReunion) {
-         List<TemaGeneral> temasGenerales = temaGeneralService.getAll();
-        nuevaReunion.agregarTemasGenerales(temasGenerales);
-        return super.save(nuevaReunion);
-    }
+  @Override
+  public void delete(Long id) {
+    Minuta minuta = minutaService.getFromReunion(id);
+    minutaService.delete(minuta.getId());
+    super.delete(id);
+  }
+
+  @Override
+  public Reunion save(Reunion nuevaReunion) {
+    List<TemaGeneral> temasGenerales = temaGeneralService.getAll();
+    nuevaReunion.agregarTemasGenerales(temasGenerales);
+    return super.save(nuevaReunion);
+  }
+
+  public Reunion getUltimaReunion() {
+    return getAll(UltimaReunion.create()).stream().findFirst().get();
+  }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
@@ -1,0 +1,44 @@
+package ar.com.kfgodel.temas.apiRest;
+
+import convention.persistent.Reunion;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReunionResourceTest extends ResourcesTemasTest {
+
+  private Reunion reunionConMinutaDel24;
+  private Reunion reunionConMinutaDel22;
+  private Reunion reunionConMinutaDel23;
+  private Reunion reunionPendienteDel27;
+  private Reunion reunionCerradaDel26;
+
+  @Override
+  public void setUp() {
+    super.setUp();
+    reunionCerradaDel26 = Reunion.create(LocalDate.of(2018, 12, 26));
+    reunionCerradaDel26.cerrarVotacion();
+    reunionCerradaDel26 = reunionService.save(reunionCerradaDel26);
+
+    reunionPendienteDel27 = reunionService.save(Reunion.create(LocalDate.of(2018, 12, 27)));
+
+    reunionConMinutaDel22 = crearReunionMinuteadaDe(LocalDate.of(2018, 12, 22));
+
+    reunionConMinutaDel24 = crearReunionMinuteadaDe(LocalDate.of(2018, 12, 24));
+
+    reunionConMinutaDel23 = crearReunionMinuteadaDe(LocalDate.of(2018, 12, 23));
+  }
+
+  private Reunion crearReunionMinuteadaDe(LocalDate fecha) {
+    Reunion reunion = Reunion.create(fecha);
+    reunion.marcarComoMinuteada();
+    return reunionService.save(reunion);
+  }
+
+  @Test
+  public void puedoPedirLaUltimaReunionCerrada() {
+    assertThat(reunionService.getUltimaReunion().getId()).isEqualTo(reunionConMinutaDel24.getId());
+  }
+}

--- a/frontend/app/helpers/promise-handling.js
+++ b/frontend/app/helpers/promise-handling.js
@@ -1,11 +1,9 @@
-import Ember from 'ember';
-
 export function promiseHandling(aPromise) {
   return aPromise.then(() => {
-    aPromise
+    return aPromise;
   }, (error) => {
     alert(error.statusText);
-    error;
+    return error;
   });
 }
 

--- a/frontend/app/router.js
+++ b/frontend/app/router.js
@@ -18,6 +18,7 @@ Router.map(function () {
   this.route('minuta', function(){
     this.route('editar', {path:":reunion_id/editar"});
     this.route('ver', {path:":reunion_id/ver"});
+    this.route('ultima-minuta', {path:"/ultima"});
     this.route('ver-txt', {path:":reunion_id/ver-txt"});
   });
 

--- a/frontend/app/routes/minuta/ultima-minuta.js
+++ b/frontend/app/routes/minuta/ultima-minuta.js
@@ -1,0 +1,11 @@
+import Ember from "ember";
+import NavigatorInjected from "../../mixins/navigator-injected";
+import MinutaServiceInjected from "../../mixins/minuta-service-injected";
+
+export default Ember.Route.extend(NavigatorInjected, MinutaServiceInjected, {
+  beforeModel: function () {
+    this.minutaService().getUltimaMinuta()
+      .then((minuta) => this.navigator().navigateToVerMinuta(minuta.reunionId),
+        (error) => console.error(error));
+  }
+});

--- a/frontend/app/services/minuta-service.js
+++ b/frontend/app/services/minuta-service.js
@@ -12,10 +12,20 @@ export default Ember.Service.extend(EmberizedResourceCreatorInjected,{
     return promiseHandling(this._minutaResource().update(minuta));
   },
 
+  getUltimaMinuta(){
+    return promiseHandling(this._ultimaMinutaResource().getAll());
+  },
+
   //private
   _minutaResource: function () {
     var resourceCreator = this.resourceCreator();
     var resource = resourceCreator.createResource('minuta');
+    return resource;
+  },
+
+  _ultimaMinutaResource: function () {
+    var resourceCreator = this.resourceCreator();
+    var resource = resourceCreator.createResource('minuta/ultimaMinuta');
     return resource;
   },
 

--- a/frontend/app/templates/components/navigation-bar.hbs
+++ b/frontend/app/templates/components/navigation-bar.hbs
@@ -13,6 +13,7 @@
       {{opcion-header link-to='proxima-roots' route='/reuniones/reuniones/' title='Proxima Roots'}}
       {{opcion-header link-to='reuniones.list' route='/reuniones/list' title='Reuniones'}}
       {{opcion-header link-to='temas-generales' route='/temas-generales' title='Temas Generales'}}
+      {{opcion-header link-to='minuta.ultima-minuta' route='/minuta/ultima' title='Última minuta'}}
     </ul>
   </div>
   <div>


### PR DESCRIPTION
En la actualidad, en gral lo que pasa es que el que cierra la reunión no es el mismo que minutea. Entonces el minuteador se encuentra con el problema de que llegar a la minuta de esa reunión es bastante complicado. Es por esto que se agrega lo siguiente:

* Se agrega un endpoint para obtener la última minuta.
* Se agrega una ruta minuta/ultima que redirige a la página de _ver minuta_ (de la última minuta al momento).
* El header tiene un link que apunta a minuta/ultima