### PR TITLE
Bloquear botón de guardar al agregar/editar tema

### DIFF
--- a/frontend/app/components/editor-de-tema.js
+++ b/frontend/app/components/editor-de-tema.js
@@ -2,6 +2,8 @@ import Ember from "ember";
 
 export default Ember.Component.extend({
 
+  guardando: false,
+
   didRender() {
     this._super(...arguments);
     $('select').material_select();
@@ -11,21 +13,21 @@ export default Ember.Component.extend({
     this.$('#titulo').focus();
   },
 
-  guardarHabilitado: Ember.computed('tema.duracion', 'tema.titulo','tema.actionItems', function () {
-    if (!this.get('tema.duracion') || !this.get('tema.titulo') ) {
-      return "disabled";
+  guardarHabilitado: Ember.computed('tema.duracion', 'tema.titulo', 'guardando', function () {
+    let propiedad = "";
+
+    if (!this.get('tema.duracion') || !this.get('tema.titulo') || this.get('guardando')) {
+      propiedad = "disabled";
     }
-    else {
-      return "";
-    }
+
+    return new Ember.Handlebars.SafeString(propiedad);
   }),
 
   actions:
     {
       guardar(funcionGuardadora){
-        if (this.get('tema.duracion') && this.get('tema.titulo') ) {
-          funcionGuardadora.call();
-        }
+        this.set('guardando', true);
+        funcionGuardadora.call();
       }
     }
 });

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -160,10 +160,6 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
         this.set('nuevoTema.duracion', duracion);
       },
 
-      cerrarModalTema() {
-        this.set('visibilidadCardDeTema', false);
-      },
-
       cerrarEditorDeTemaNuevo() {
         this.set('mostrandoFormularioXTemaNuevo', false);
         this._cerrarModalTema();


### PR DESCRIPTION
Por temas de velocidad, si estoy agregando un tema y pongo _guardar_ tarda y si vuelvo a clickearlo mientras se estaba guardando, agrega otro tema. Se soluciona bloqueando el botón cuando se está guardando.