### PR TITLE
Ingresar tratado automaticamente al guardar tema con datos

### DIFF
--- a/frontend/app/controllers/minuta/editar.js
+++ b/frontend/app/controllers/minuta/editar.js
@@ -85,6 +85,14 @@ export default Ember.Controller.extend(MinutaServiceInjected, TemaDeMinutaServic
         delete actionItem.usuariosSeleccionables;
       });
 
+      if (
+        this.get("temasPendientes").includes(tema) &&
+        tema.conclusion !== "" &&
+        tema.actionItems.length > 0
+      ) {
+        tema.set("fueTratado", true);
+      }
+
       this.temaDeMinutaService().updateTemaDeMinuta(tema)
         .then((response) => {
           this._mostrarUsuariosSinMail(response);


### PR DESCRIPTION
La condicion se marca como tratada automaticamente al guardar un tema pendiente con conclusion y/o action items. Si el tema editado esta en la lista de temas tratados, permite marcarlo como no tratado manualmente, para poder tener tema no tratado con conclusion si asi se lo desea.