### PR TITLE
Agrego el archivo nvmrc para fijar node a lts/dubnium

### DIFF
--- a/frontend/.nvmrc
+++ b/frontend/.nvmrc
@@ -1,0 +1,1 @@
+lts/dubnium


### PR DESCRIPTION
Node-sass no corre con node 12 en adelante, al menos en la version de ember-cli-sass que usa el proyecto. Este archivo permite hacer `nvm use` si tenes instalado [nvm](https://github.com/nvm-sh/nvm). Esto permite correr el frontend con una version de node compatible.