### PR TITLE
Backend cargar action items de la reunion anterior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ before_install:
   - docker run -d -p 127.0.0.1:80:4567  maven:3-jdk-12 /bin/sh -c "git clone --depth=50 https://github.com/10PinesLabs/votacion-roots.git 10PinesLabs/votacion-roots; cd votacion-roots"
 script:
   - mvn -Dmaven.javadoc.skip=true test
-cache:
+cache:ma
   directories:
     - $HOME/.m2
     - frontend/node_modules
     - frontend/bower_components
+env:
+  global:
+    - JAVA_HOME=/usr/lib/jvm/java-9-oracle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - oraclejdk9
 services:
   - docker
 before_install:
@@ -11,6 +13,4 @@ cache:ma
     - $HOME/.m2
     - frontend/node_modules
     - frontend/bower_components
-env:
-  global:
-    - JAVA_HOME=/usr/lib/jvm/java-9-oracle
+

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -135,8 +135,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/backend/src/main/java/ar/com/kfgodel/temas/application/TemasApplication.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/application/TemasApplication.java
@@ -13,14 +13,11 @@ import ar.com.kfgodel.webbyconvention.api.WebServer;
 import ar.com.kfgodel.webbyconvention.api.config.WebServerConfiguration;
 import ar.com.kfgodel.webbyconvention.impl.JettyWebServer;
 import ar.com.kfgodel.webbyconvention.impl.config.ConfigurationByConvention;
-import convention.persistent.TemaGeneral;
 import convention.services.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -32,6 +29,12 @@ public class TemasApplication implements Application {
     public static Logger LOG = LoggerFactory.getLogger(TemasApplication.class);
 
     private TemasConfiguration config;
+
+    public static Application create(TemasConfiguration config) {
+        TemasApplication application = new TemasApplication();
+        application.setConfiguration(config);
+        return application;
+    }
 
     @Override
     public WebServer getWebServerModule() {
@@ -60,13 +63,6 @@ public class TemasApplication implements Application {
     @Override
     public DependencyInjector injector() {
         return config.getInjector();
-    }
-
-
-    public static Application create(TemasConfiguration config) {
-        TemasApplication application = new TemasApplication();
-        application.setConfiguration(config);
-        return application;
     }
 
     /**
@@ -136,14 +132,14 @@ public class TemasApplication implements Application {
 
     public void clearServices() {
         getServiceClasses().forEach(serviceClass -> {
-            injector().getImplementationFor(serviceClass).ifPresent(Service::deleteAll);
+            getImplementationFor(serviceClass).deleteAll();
         });
     }
 
     private List<Class<? extends Service>> getServiceClasses() {
         return Arrays.asList(
-                TemaDeMinutaService.class,
                 MinutaService.class,
+                TemaDeMinutaService.class,
                 TemaService.class,
                 TemaGeneralService.class,
                 ReunionService.class,

--- a/backend/src/main/java/ar/com/kfgodel/temas/application/TemasApplication.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/application/TemasApplication.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * This type represents the whole application as a single object.<br>
@@ -139,14 +140,14 @@ public class TemasApplication implements Application {
         });
     }
 
-    private Collection<Class<? extends Service>> getServiceClasses() {
+    private List<Class<? extends Service>> getServiceClasses() {
         return Arrays.asList(
-                ReunionService.class,
+                TemaDeMinutaService.class,
+                MinutaService.class,
                 TemaService.class,
                 TemaGeneralService.class,
-                UsuarioService.class,
-                MinutaService.class,
-                TemaDeMinutaService.class
+                ReunionService.class,
+                UsuarioService.class
         );
     }
 }

--- a/backend/src/main/java/convention/persistent/Reunion.java
+++ b/backend/src/main/java/convention/persistent/Reunion.java
@@ -18,7 +18,6 @@ public class Reunion extends PersistableSupport {
 
     public static final String AGREGAR_TEMA_PARA_PROPONER_PINOS_COMO_ROOT_ERROR_MSG = "no se puede agregar un tema para proponer pinos como root";
     public static final String NO_HAY_TEMA_PARA_REPASAR_ACTION_ITEMS_ERROR_MSG = "no hay tema para repasar action items";
-    public static final String TITULO_DE_TEMA_PARA_REPASAR_ACTION_ITEMS = "Repasar action items de la root anterior";
     public static final String fecha_FIELD = "fecha";
     public static final String status_FIELD = "status";
     public static final String temasPropuestos_FIELD = "temasPropuestos";
@@ -136,7 +135,7 @@ public class Reunion extends PersistableSupport {
 
     public void cargarSiExisteElTemaParaRepasarActionItemsDe(Minuta unaMinuta) {
         temasPropuestos.stream()
-                .filter(unTema -> Objects.equals(unTema.getTitulo(), TITULO_DE_TEMA_PARA_REPASAR_ACTION_ITEMS))
+                .filter(unTema -> Objects.equals(unTema.getTitulo(), TemaParaRepasarActionItems.TITULO))
                 .findFirst()
                 .ifPresent((temaParaRepasarActionItems) -> {
                     TemaParaRepasarActionItems nuevoTemaParaRepasarActionItems = TemaParaRepasarActionItems.create(unaMinuta, temaParaRepasarActionItems);

--- a/backend/src/main/java/convention/persistent/Reunion.java
+++ b/backend/src/main/java/convention/persistent/Reunion.java
@@ -17,6 +17,8 @@ import java.util.*;
 public class Reunion extends PersistableSupport {
 
     public static final String AGREGAR_TEMA_PARA_PROPONER_PINOS_COMO_ROOT_ERROR_MSG = "no se puede agregar un tema para proponer pinos como root";
+    public static final String NO_HAY_TEMA_PARA_REPASAR_ACTION_ITEMS_ERROR_MSG = "no hay tema para repasar action items";
+    public static final String TITULO_DE_TEMA_PARA_REPASAR_ACTION_ITEMS = "Repasar action items de la root anterior";
     @NotNull
     private LocalDate fecha;
     public static final String fecha_FIELD = "fecha";
@@ -133,5 +135,18 @@ public class Reunion extends PersistableSupport {
         temaParaProponerPinos.setReunion(this);
         temasPropuestos.add(temaParaProponerPinos);
         return temaParaProponerPinos;
+    }
+
+    public void cargarElTemaParaRepasarActionItemsDe(Minuta unaMinuta) {
+        Optional<TemaDeReunion> temaParaRepasarActionItems = temasPropuestos.stream()
+                .filter(unTema -> Objects.equals(unTema.getTitulo(), TITULO_DE_TEMA_PARA_REPASAR_ACTION_ITEMS))
+                .findFirst();
+
+        if (!temaParaRepasarActionItems.isPresent()) {
+            throw new RuntimeException(NO_HAY_TEMA_PARA_REPASAR_ACTION_ITEMS_ERROR_MSG);
+        }
+
+        TemaParaRepasarActionItems nuevoTemaParaRepasarActionItems = new TemaParaRepasarActionItems(unaMinuta, temaParaRepasarActionItems.get());
+        temasPropuestos.set(temasPropuestos.indexOf(temaParaRepasarActionItems.get()), nuevoTemaParaRepasarActionItems);
     }
 }

--- a/backend/src/main/java/convention/persistent/Reunion.java
+++ b/backend/src/main/java/convention/persistent/Reunion.java
@@ -134,13 +134,13 @@ public class Reunion extends PersistableSupport {
         return temaParaProponerPinos;
     }
 
-    public void cargarElTemaParaRepasarActionItemsDe(Minuta unaMinuta) {
-        TemaDeReunion temaParaRepasarActionItems = temasPropuestos.stream()
+    public void cargarSiExisteElTemaParaRepasarActionItemsDe(Minuta unaMinuta) {
+        temasPropuestos.stream()
                 .filter(unTema -> Objects.equals(unTema.getTitulo(), TITULO_DE_TEMA_PARA_REPASAR_ACTION_ITEMS))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException(NO_HAY_TEMA_PARA_REPASAR_ACTION_ITEMS_ERROR_MSG));
-
-        TemaParaRepasarActionItems nuevoTemaParaRepasarActionItems = TemaParaRepasarActionItems.create(unaMinuta, temaParaRepasarActionItems);
-        temasPropuestos.set(temasPropuestos.indexOf(temaParaRepasarActionItems), nuevoTemaParaRepasarActionItems);
+                .ifPresent((temaParaRepasarActionItems) -> {
+                    TemaParaRepasarActionItems nuevoTemaParaRepasarActionItems = TemaParaRepasarActionItems.create(unaMinuta, temaParaRepasarActionItems);
+                    temasPropuestos.set(temasPropuestos.indexOf(temaParaRepasarActionItems), nuevoTemaParaRepasarActionItems);
+                });
     }
 }

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -176,4 +176,8 @@ public abstract class TemaDeReunion extends Tema {
     public Boolean esParaProponerPinosARoot() {
         return false;
     }
+
+    public Boolean esParaRepasarActionItems() {
+        return false;
+    }
 }

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -23,6 +23,7 @@ public abstract class TemaDeReunion extends Tema {
     public static final String interesados_FIELD = "interesados";
     public static final String obligatoriedad_FIELD = "obligatoriedad";
     public static final String temaGenerador_FIELD = "temaGenerador";
+    public static final String ERROR_AGREGAR_INTERESADO = "No se puede agregar un interesado a un tema obligatorio";
     @ManyToOne
     private Reunion reunion;
     private Integer prioridad;
@@ -33,10 +34,6 @@ public abstract class TemaDeReunion extends Tema {
     private ObligatoriedadDeTema obligatoriedad;
     @ManyToOne
     private TemaGeneral temaGenerador;
-
-    public static String mensajeDeErrorAlAgregarInteresado() {
-        return "No se puede agregar un interesado a un tema obligatorio";
-    }
 
     public ObligatoriedadDeTema getObligatoriedad() {
         return obligatoriedad;
@@ -80,7 +77,7 @@ public abstract class TemaDeReunion extends Tema {
         if (this.puedeSerVotado())
             this.getInteresados().add(votante);
         else
-            throw new TemaDeReunionException(mensajeDeErrorAlAgregarInteresado());
+            throw new TemaDeReunionException(TemaDeReunion.ERROR_AGREGAR_INTERESADO);
     }
 
     public void quitarInteresado(Usuario votante) {

--- a/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
+++ b/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
@@ -5,15 +5,17 @@ import java.util.List;
 public class TemaParaRepasarActionItems extends TemaDeReunion {
     private List<TemaDeMinuta> temasParaRepasar;
 
-    public TemaParaRepasarActionItems(Minuta unaMinuta, TemaDeReunion unTemaDeReunion) {
-        setTitulo(unTemaDeReunion.getTitulo());
-        setDescripcion(unTemaDeReunion.getDescripcion());
-        setObligatoriedad(unTemaDeReunion.getObligatoriedad());
-        setReunion(unTemaDeReunion.getReunion());
-        setDuracion(unTemaDeReunion.getDuracion());
-        setAutor(unTemaDeReunion.getAutor());
-        setInteresados(unTemaDeReunion.getInteresados());
-        temasParaRepasar = unaMinuta.getTemas();
+    public static TemaParaRepasarActionItems create(Minuta unaMinuta, TemaDeReunion unTemaDeReunion) {
+        TemaParaRepasarActionItems tema = new TemaParaRepasarActionItems();
+        tema.setTitulo(unTemaDeReunion.getTitulo());
+        tema.setDescripcion(unTemaDeReunion.getDescripcion());
+        tema.setObligatoriedad(unTemaDeReunion.getObligatoriedad());
+        tema.setReunion(unTemaDeReunion.getReunion());
+        tema.setDuracion(unTemaDeReunion.getDuracion());
+        tema.setAutor(unTemaDeReunion.getAutor());
+        tema.setInteresados(unTemaDeReunion.getInteresados());
+        tema.temasParaRepasar = unaMinuta.getTemas();
+        return tema;
     }
 
     public List<TemaDeMinuta> getTemasParaRepasar() {

--- a/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
+++ b/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
@@ -9,6 +9,9 @@ import java.util.List;
 @Entity
 public class TemaParaRepasarActionItems extends TemaDeReunion {
 
+    public static final String TITULO = "Repasar action items de la root anterior";
+    public static final String temasParaRepasar_FIELD = "temasParaRepasar";
+
     @OneToMany
     @JoinColumn(name = "repasar_id")
     private List<TemaDeMinuta> temasParaRepasar = new ArrayList<>();

--- a/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
+++ b/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
@@ -1,7 +1,7 @@
 package convention.persistent;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,7 +9,8 @@ import java.util.List;
 @Entity
 public class TemaParaRepasarActionItems extends TemaDeReunion {
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany
+    @JoinColumn(name = "repasar_id")
     private List<TemaDeMinuta> temasParaRepasar = new ArrayList<>();
 
     public static TemaParaRepasarActionItems create(Minuta unaMinuta, TemaDeReunion unTemaDeReunion) {

--- a/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
+++ b/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
@@ -1,0 +1,32 @@
+package convention.persistent;
+
+import java.util.List;
+
+public class TemaParaRepasarActionItems extends TemaDeReunion {
+    private List<TemaDeMinuta> temasParaRepasar;
+
+    public TemaParaRepasarActionItems(Minuta unaMinuta, TemaDeReunion unTemaDeReunion) {
+        setTitulo(unTemaDeReunion.getTitulo());
+        setDescripcion(unTemaDeReunion.getDescripcion());
+        setObligatoriedad(unTemaDeReunion.getObligatoriedad());
+        setReunion(unTemaDeReunion.getReunion());
+        setDuracion(unTemaDeReunion.getDuracion());
+        setAutor(unTemaDeReunion.getAutor());
+        setInteresados(unTemaDeReunion.getInteresados());
+        temasParaRepasar = unaMinuta.getTemas();
+    }
+
+    public List<TemaDeMinuta> getTemasParaRepasar() {
+        return temasParaRepasar;
+    }
+
+    @Override
+    protected TemaDeReunion createCopy() {
+        return super.copy();
+    }
+
+    @Override
+    public Boolean esParaRepasarActionItems() {
+        return true;
+    }
+}

--- a/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
+++ b/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
@@ -1,9 +1,16 @@
 package convention.persistent;
 
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 
+@Entity
 public class TemaParaRepasarActionItems extends TemaDeReunion {
-    private List<TemaDeMinuta> temasParaRepasar;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<TemaDeMinuta> temasParaRepasar = new ArrayList<>();
 
     public static TemaParaRepasarActionItems create(Minuta unaMinuta, TemaDeReunion unTemaDeReunion) {
         TemaParaRepasarActionItems tema = new TemaParaRepasarActionItems();
@@ -14,7 +21,7 @@ public class TemaParaRepasarActionItems extends TemaDeReunion {
         tema.setDuracion(unTemaDeReunion.getDuracion());
         tema.setAutor(unTemaDeReunion.getAutor());
         tema.setInteresados(unTemaDeReunion.getInteresados());
-        tema.temasParaRepasar = unaMinuta.getTemas();
+        tema.temasParaRepasar.addAll(unaMinuta.getTemas());
         return tema;
     }
 

--- a/backend/src/main/java/convention/rest/api/ReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/ReunionResource.java
@@ -47,8 +47,7 @@ public class ReunionResource {
 
         if (reunion.getStatus() == StatusDeReunion.PENDIENTE) {
             List<TemaDeReunion> listaDeTemasNuevos = reunion.getTemasPropuestos().stream().
-                    map(temaDeReunion ->
-                            temaDeReunion.copy()).collect(Collectors.toList());
+                    map(TemaDeReunion::copy).collect(Collectors.toList());
             listaDeTemasNuevos.forEach(temaDeReunion -> temaDeReunion.ocultarVotosPara(userId));
             listaDeTemasNuevos.sort(Comparator.comparing(TemaDeReunion::getId));
             Collections.shuffle(listaDeTemasNuevos, new Random(securityContext.getUserPrincipal().hashCode())); //random turbio
@@ -70,6 +69,7 @@ public class ReunionResource {
         Reunion reunionCerrada = reunionService.updateAndMapping(id,
                 reunion -> {
                     reunion.cerrarVotacion();
+                    reunionService.cargarActionItemsDeLaUltimaMinutaSiExisteElTema(reunion);
                     return reunion;
                 });
          return getResourceHelper().convertir(reunionCerrada, ReunionTo.class);
@@ -151,9 +151,7 @@ public class ReunionResource {
         }
         Reunion nuevaReunion = reunionService.save(reunion);
 
-        ReunionTo reunionTo = getResourceHelper().convertir(nuevaReunion, ReunionTo.class);
-
-        return reunionTo;
+        return getResourceHelper().convertir(nuevaReunion, ReunionTo.class);
     }
 
     public ResourceHelper getResourceHelper() {

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -74,7 +74,7 @@ public class TemaDeReunionResource {
         try {
             temaDeReunion.agregarInteresado(usuarioActual);
         } catch (Exception exception) {
-            throw new WebApplicationException(TemaDeReunion.mensajeDeErrorAlAgregarInteresado(), Response.Status.CONFLICT);
+            throw new WebApplicationException(TemaDeReunion.ERROR_AGREGAR_INTERESADO, Response.Status.CONFLICT);
         }
         return temaDeReunion;
     }

--- a/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
@@ -14,7 +14,8 @@ import java.util.List;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "tipo")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = TemaParaProponerPinosARootTo.class, name = "proponerPinos"),
-        @JsonSubTypes.Type(value = TemaDeReunionConDescripcionTo.class, name = "conDescripcion")
+        @JsonSubTypes.Type(value = TemaDeReunionConDescripcionTo.class, name = "conDescripcion"),
+        @JsonSubTypes.Type(value = TemaParaRepasarActionItemsTo.class, name = "repasarActionItems")
 })
 public class TemaDeReunionTo extends PersistableToSupport {
     @CopyFromAndTo(TemaDeReunion.duracion_FIELD)

--- a/backend/src/main/java/convention/rest/api/tos/TemaParaRepasarActionItemsTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaParaRepasarActionItemsTo.java
@@ -1,0 +1,39 @@
+package convention.rest.api.tos;
+
+import convention.persistent.TemaParaRepasarActionItems;
+import convention.persistent.Usuario;
+import net.sf.kfgodel.bean2bean.annotations.CopyFromAndTo;
+
+import java.util.List;
+
+public class TemaParaRepasarActionItemsTo extends TemaDeReunionTo {
+
+    @CopyFromAndTo(TemaParaRepasarActionItems.temasParaRepasar_FIELD)
+    private List<TemaDeMinutaTo> temasParaRepasar;
+
+    public TemaParaRepasarActionItemsTo() {
+    }
+
+    public static TemaParaRepasarActionItemsTo create(Usuario unAutor,
+                                                      String unaDuracion,
+                                                      String unaObligatoriedad,
+                                                      String unTitulo,
+                                                      List<TemaDeMinutaTo> temasParaRepasar) {
+        TemaParaRepasarActionItemsTo to = new TemaParaRepasarActionItemsTo();
+        to.setIdDeAutor(unAutor.getId());
+        to.setAutor(unAutor.getName());
+        to.setDuracion(unaDuracion);
+        to.setObligatoriedad(unaObligatoriedad);
+        to.setTitulo(unTitulo);
+        to.setTemasParaRepasar(temasParaRepasar);
+        return to;
+    }
+
+    public List<TemaDeMinutaTo> getTemasParaRepasar() {
+        return temasParaRepasar;
+    }
+
+    public void setTemasParaRepasar(List<TemaDeMinutaTo> temasParaRepasar) {
+        this.temasParaRepasar = temasParaRepasar;
+    }
+}

--- a/backend/src/main/java/convention/services/ReunionService.java
+++ b/backend/src/main/java/convention/services/ReunionService.java
@@ -7,7 +7,6 @@ import ar.com.kfgodel.temas.filters.reuniones.ProximaReunion;
 import ar.com.kfgodel.temas.filters.reuniones.UltimaReunion;
 import convention.persistent.Minuta;
 import convention.persistent.Reunion;
-import convention.persistent.TemaGeneral;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -49,5 +48,11 @@ public class ReunionService extends Service<Reunion> {
 
   public Reunion getUltimaReunion() {
     return getAll(UltimaReunion.create()).stream().findFirst().get();
+  }
+
+  public Reunion cargarActionItemsDeLaUltimaMinutaSiExisteElTema(Reunion nuevaReunion){
+    Minuta ultimaMinuta = minutaService.getUltimaMinuta();
+    nuevaReunion.cargarSiExisteElTemaParaRepasarActionItemsDe(ultimaMinuta);
+    return nuevaReunion;
   }
 }

--- a/backend/src/main/java/convention/transformers/TemaDeReunion2ToConverter.java
+++ b/backend/src/main/java/convention/transformers/TemaDeReunion2ToConverter.java
@@ -4,9 +4,11 @@ import com.google.inject.Inject;
 import convention.persistent.TemaDeReunion;
 import convention.persistent.TemaDeReunionConDescripcion;
 import convention.persistent.TemaParaProponerPinosARoot;
+import convention.persistent.TemaParaRepasarActionItems;
 import convention.rest.api.tos.TemaDeReunionConDescripcionTo;
 import convention.rest.api.tos.TemaDeReunionTo;
 import convention.rest.api.tos.TemaParaProponerPinosARootTo;
+import convention.rest.api.tos.TemaParaRepasarActionItemsTo;
 import net.sf.kfgodel.bean2bean.conversion.GeneralTypeConverter;
 import net.sf.kfgodel.bean2bean.conversion.SpecializedTypeConverter;
 import net.sf.kfgodel.bean2bean.conversion.TypeConverter;
@@ -37,8 +39,9 @@ public class TemaDeReunion2ToConverter implements SpecializedTypeConverter<TemaD
         return baseConverter.getGeneralConverterByName(AnnotatedClassConverter.class.getName());
     }
 
-    private Map<Type, Type> toClass = new HashMap<Type, Type>() {{
+    private Map<Type, Type> toClass = new HashMap<>() {{
         put(TemaDeReunionConDescripcion.class, TemaDeReunionConDescripcionTo.class);
         put(TemaParaProponerPinosARoot.class, TemaParaProponerPinosARootTo.class);
+        put(TemaParaRepasarActionItems.class, TemaParaRepasarActionItemsTo.class);
     }};
 }

--- a/backend/src/main/java/convention/transformers/To2TemaDeReunionConverter.java
+++ b/backend/src/main/java/convention/transformers/To2TemaDeReunionConverter.java
@@ -4,9 +4,11 @@ import com.google.inject.Inject;
 import convention.persistent.TemaDeReunion;
 import convention.persistent.TemaDeReunionConDescripcion;
 import convention.persistent.TemaParaProponerPinosARoot;
+import convention.persistent.TemaParaRepasarActionItems;
 import convention.rest.api.tos.TemaDeReunionConDescripcionTo;
 import convention.rest.api.tos.TemaDeReunionTo;
 import convention.rest.api.tos.TemaParaProponerPinosARootTo;
+import convention.rest.api.tos.TemaParaRepasarActionItemsTo;
 import convention.transformers.persistibles.PersistableTo2PersistableConverter;
 import net.sf.kfgodel.bean2bean.conversion.SpecializedTypeConverter;
 import net.sf.kfgodel.bean2bean.conversion.TypeConverter;
@@ -36,8 +38,9 @@ public class To2TemaDeReunionConverter implements SpecializedTypeConverter<TemaD
         return domainClass.get(toType);
     }
 
-    private Map<Type, Type> domainClass = new HashMap<Type, Type>() {{
+    private Map<Type, Type> domainClass = new HashMap<>() {{
         put(TemaDeReunionConDescripcionTo.class, TemaDeReunionConDescripcion.class);
         put(TemaParaProponerPinosARootTo.class, TemaParaProponerPinosARoot.class);
+        put(TemaParaRepasarActionItemsTo.class, TemaParaRepasarActionItems.class);
     }};
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
@@ -5,6 +5,8 @@ import ar.com.kfgodel.temas.application.Application;
 import ar.com.kfgodel.temas.application.TemasApplication;
 import ar.com.kfgodel.temas.config.AuthenticatedTestConfig;
 import ar.com.kfgodel.temas.config.TemasConfiguration;
+import ar.com.kfgodel.temas.helpers.TestHelper;
+import convention.persistent.Usuario;
 import convention.rest.api.ReunionResource;
 import convention.rest.api.TemaDeReunionResource;
 import convention.services.*;
@@ -32,6 +34,7 @@ public abstract class ResourceTest {
 
     private static Thread serverThread;
     private static TemasApplication application;
+    private TestHelper helper = new TestHelper();
 
     @BeforeClass
     public static void applicationSetUp() {
@@ -82,9 +85,6 @@ public abstract class ResourceTest {
 
     @Before
     public void setUp() throws IOException {
-        client = HttpClientBuilder.create().build();
-        getClient().execute(new HttpGet(pathRelativeToHost("j_security_check")));
-
         ReunionResource.create(getInjector());
         TemaDeReunionResource.create(getInjector());
         reunionService = getApplication().getImplementationFor(ReunionService.class);
@@ -92,6 +92,11 @@ public abstract class ResourceTest {
         temaGeneralService = getApplication().getImplementationFor(TemaGeneralService.class);
         usuarioService = getApplication().getImplementationFor(UsuarioService.class);
         minutaService = getApplication().getImplementationFor(MinutaService.class);
+        usuarioService.save(helper.unFeche());
+        usuarioService.save(helper.unSandro());
+
+        client = HttpClientBuilder.create().build();
+        getClient().execute(new HttpGet(pathRelativeToHost("j_security_check")));
     }
 
     @After

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
@@ -5,8 +5,8 @@ import ar.com.kfgodel.temas.application.Application;
 import ar.com.kfgodel.temas.application.TemasApplication;
 import ar.com.kfgodel.temas.config.AuthenticatedTestConfig;
 import ar.com.kfgodel.temas.config.TemasConfiguration;
+import ar.com.kfgodel.temas.helpers.PersistentTestHelper;
 import ar.com.kfgodel.temas.helpers.TestHelper;
-import convention.persistent.Usuario;
 import convention.rest.api.ReunionResource;
 import convention.rest.api.TemaDeReunionResource;
 import convention.services.*;
@@ -34,7 +34,14 @@ public abstract class ResourceTest {
 
     private static Thread serverThread;
     private static TemasApplication application;
-    private TestHelper helper = new TestHelper();
+    TemaService temaService;
+    UsuarioService usuarioService;
+    ReunionService reunionService;
+    MinutaService minutaService;
+    TemaGeneralService temaGeneralService;
+    TestHelper helper = new TestHelper();
+    PersistentTestHelper persistentHelper;
+    private HttpClient client;
 
     @BeforeClass
     public static void applicationSetUp() {
@@ -67,21 +74,13 @@ public abstract class ResourceTest {
         }
     }
 
-    private static Application getApplication() {
+    static Application getApplication() {
         return application;
     }
 
     static DependencyInjector getInjector() {
         return getApplication().injector();
     }
-
-
-    private HttpClient client;
-    TemaService temaService;
-    UsuarioService usuarioService;
-    ReunionService reunionService;
-    MinutaService minutaService;
-    TemaGeneralService temaGeneralService;
 
     @Before
     public void setUp() throws IOException {
@@ -97,6 +96,7 @@ public abstract class ResourceTest {
 
         client = HttpClientBuilder.create().build();
         getClient().execute(new HttpGet(pathRelativeToHost("j_security_check")));
+        persistentHelper = new PersistentTestHelper(getApplication());
     }
 
     @After

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
@@ -1,6 +1,5 @@
 package ar.com.kfgodel.temas.apiRest;
 
-import ar.com.kfgodel.temas.helpers.TestHelper;
 import convention.persistent.*;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -15,11 +14,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReunionResourceTest extends ResourceTest {
 
-    private TestHelper helper = new TestHelper();
-
     @Test
     public void testProponerPinoComoRootAgregaUnTemaALaReunion() throws IOException {
-        Long idReunion = crearUnaReunion().getId();
+        Long idReunion = persistentHelper.crearUnaReunion().getId();
 
         HttpResponse response = makeJsonPostRequest("reuniones/" + idReunion + "/propuestas", jsonDeUnaPropuesta());
 
@@ -30,7 +27,7 @@ public class ReunionResourceTest extends ResourceTest {
 
     @Test
     public void testProponerPinoComoRootAgregaUnaPropuestaParaElPino() throws IOException {
-        Long idReunion = crearUnaReunion().getId();
+        Long idReunion = persistentHelper.crearUnaReunion().getId();
 
         String unNombre = "nombre";
         makeJsonPostRequest("reuniones/" + idReunion + "/propuestas", jsonDeUnaPropuestaPara(unNombre));
@@ -45,7 +42,7 @@ public class ReunionResourceTest extends ResourceTest {
 
     @Test
     public void testProponerPinoComoRootResponseConLaReunionActualizada() throws IOException {
-        Long idReunion = crearUnaReunion().getId();
+        Long idReunion = persistentHelper.crearUnaReunion().getId();
 
         HttpResponse response = makeJsonPostRequest("reuniones/" + idReunion + "/propuestas", jsonDeUnaPropuesta());
 
@@ -58,7 +55,7 @@ public class ReunionResourceTest extends ResourceTest {
 
     @Test
     public void testGetDeReunionDistingueLosTiposDeTema() throws IOException {
-        Reunion unaReunion = crearUnaReunionConTemas();
+        Reunion unaReunion = persistentHelper.crearUnaReunionConTemas();
 
         HttpResponse response = makeGetRequest("reuniones/" + unaReunion.getId());
 
@@ -86,21 +83,6 @@ public class ReunionResourceTest extends ResourceTest {
 
     private Usuario unUsuarioPersistido() {
         return usuarioService.getAll().get(0);
-    }
-
-    private Reunion crearUnaReunionConTemas() {
-        Reunion unaReunion = helper.unaReunion();
-        TemaDeReunion unTema = TemaDeReunionConDescripcion.create();
-        unTema.setReunion(unaReunion);
-        unaReunion.agregarTema(unTema);
-        reunionService.save(unaReunion);
-        return unaReunion;
-    }
-
-    private Reunion crearUnaReunion() {
-        Reunion reunion = helper.unaReunion();
-        reunionService.save(reunion);
-        return reunion;
     }
 
     private String jsonDeUnaPropuesta() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -19,8 +19,6 @@ public class TemaDeReunionResourceTest extends ResourceTest {
 
     public static final String CAMPO_DE_TIPO = "tipo";
 
-    private TestHelper helper = new TestHelper();
-
     @Test
     public void testGetDeTemaDeReunionContieneElTipoDeTemaParaTemasParaProponerPinosARoot() throws IOException {
         Long idTema = crearUnTemaParaProponerPinosARoot().getId();

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/MinutaTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/MinutaTest.java
@@ -86,7 +86,7 @@ public class MinutaTest {
     public void testSePuedenCargarActionItemsCuandoHayUnTemaParaEso() {
         Minuta unaMinuta = helper.unaMinuta();
         Reunion unaReunion = helper.unaReunion();
-        TemaDeReunion unTemaConTituloRepasarActionItems = helper.unTemaDeReunionConTitulo(Reunion.TITULO_DE_TEMA_PARA_REPASAR_ACTION_ITEMS);
+        TemaDeReunion unTemaConTituloRepasarActionItems = helper.unTemaDeReunionConTitulo(TemaParaRepasarActionItems.TITULO);
         unaReunion.agregarTema(unTemaConTituloRepasarActionItems);
 
         unaReunion.cargarSiExisteElTemaParaRepasarActionItemsDe(unaMinuta);
@@ -101,7 +101,7 @@ public class MinutaTest {
     }
 
     private Reunion crearReunion() {
-        return Reunion.create(LocalDate.of(2017, 06, 26));
+        return Reunion.create(LocalDate.of(2017, 6, 26));
     }
 
     private Usuario crearUsuario() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/MinutaTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/MinutaTest.java
@@ -1,21 +1,27 @@
 package ar.com.kfgodel.temas.domain;
 
+import ar.com.kfgodel.temas.helpers.TestHelper;
 import convention.persistent.*;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.validation.constraints.Min;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
  * Created by sandro on 06/07/17.
  */
 public class MinutaTest {
+
+    private TestHelper helper = new TestHelper();
 
     @Test
     public void test01UnaMinutaNuevaNoTieneAsistentesSiNingunTemaFueVotado() {
@@ -38,7 +44,7 @@ public class MinutaTest {
     }
 
     @Test
-    public void test03UnaMinutaTieneUnSoloAsistentePorMasQueHayaVotadoMasDeUnaVezLaMismaPersona(){
+    public void test03UnaMinutaTieneUnSoloAsistentePorMasQueHayaVotadoMasDeUnaVezLaMismaPersona() {
         Reunion reunion = crearReunion();
         TemaDeReunion unTema = crearTema();
         Usuario unVotante = crearUsuario();
@@ -50,7 +56,7 @@ public class MinutaTest {
     }
 
     @Test
-    public void test04UnaMinutaTieneLosTemasPropuestosConLaMismaCantidadDeVotantes(){
+    public void test04UnaMinutaTieneLosTemasPropuestosConLaMismaCantidadDeVotantes() {
         Reunion reunion = crearReunion();
 
         TemaDeReunion unTema = crearTema();
@@ -67,7 +73,31 @@ public class MinutaTest {
         assertThat(minuta.getAsistentes()).containsExactly(unVotante);
         List<Integer> cantidadDeVotantesPorTema = minuta.getReunion().getTemasPropuestos().stream().map(tema -> tema.getInteresados().size()).collect(Collectors.toList());
         assertThat(cantidadDeVotantesPorTema)
-                .isEqualTo(Arrays.asList(1,2));
+                .isEqualTo(Arrays.asList(1, 2));
+    }
+
+    @Test
+    public void testNoSePuedenCargarActionItemsCuandoNoHayUnTemaParaEso() {
+        Minuta unaMinuta = helper.unaMinuta();
+        Reunion unaReunion = helper.unaReunion();
+
+        assertThatThrownBy(() -> {
+            unaReunion.cargarElTemaParaRepasarActionItemsDe(unaMinuta);
+        }).hasMessage(Reunion.NO_HAY_TEMA_PARA_REPASAR_ACTION_ITEMS_ERROR_MSG);
+    }
+
+    @Test
+    public void testSePuedenCargarActionItemsCuandoHayUnTemaParaEso() {
+        Minuta unaMinuta = helper.unaMinuta();
+        Reunion unaReunion = helper.unaReunion();
+        TemaDeReunion unTemaConTituloRepasarActionItems = helper.unTemaDeReunionConTitulo(Reunion.TITULO_DE_TEMA_PARA_REPASAR_ACTION_ITEMS);
+        unaReunion.agregarTema(unTemaConTituloRepasarActionItems);
+
+        unaReunion.cargarElTemaParaRepasarActionItemsDe(unaMinuta);
+
+        List<TemaDeReunion> temasPropuestos = unaReunion.getTemasPropuestos();
+        assertThat(temasPropuestos).hasSize(1);
+        assertThat(temasPropuestos).anyMatch(TemaDeReunion::esParaRepasarActionItems);
     }
 
     private TemaDeReunion crearTema() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/MinutaTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/MinutaTest.java
@@ -5,9 +5,7 @@ import convention.persistent.*;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.validation.constraints.Min;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -80,10 +78,8 @@ public class MinutaTest {
     public void testNoSePuedenCargarActionItemsCuandoNoHayUnTemaParaEso() {
         Minuta unaMinuta = helper.unaMinuta();
         Reunion unaReunion = helper.unaReunion();
-
-        assertThatThrownBy(() -> {
-            unaReunion.cargarElTemaParaRepasarActionItemsDe(unaMinuta);
-        }).hasMessage(Reunion.NO_HAY_TEMA_PARA_REPASAR_ACTION_ITEMS_ERROR_MSG);
+        unaReunion.cargarSiExisteElTemaParaRepasarActionItemsDe(unaMinuta);
+        assertThat(unaReunion.getTemasPropuestos().size()).isEqualTo(0);
     }
 
     @Test
@@ -93,7 +89,7 @@ public class MinutaTest {
         TemaDeReunion unTemaConTituloRepasarActionItems = helper.unTemaDeReunionConTitulo(Reunion.TITULO_DE_TEMA_PARA_REPASAR_ACTION_ITEMS);
         unaReunion.agregarTema(unTemaConTituloRepasarActionItems);
 
-        unaReunion.cargarElTemaParaRepasarActionItemsDe(unaMinuta);
+        unaReunion.cargarSiExisteElTemaParaRepasarActionItemsDe(unaMinuta);
 
         List<TemaDeReunion> temasPropuestos = unaReunion.getTemasPropuestos();
         assertThat(temasPropuestos).hasSize(1);

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -61,7 +61,7 @@ public class TemaDeReunionTest {
             unTemaObligatorio.agregarInteresado(unUsuario);
             fail("No debería permitir agregar un interesado a un tema obligatorio");
         }catch (Exception exception){
-            Assert.assertThat(exception.getMessage(), is(TemaDeReunion.mensajeDeErrorAlAgregarInteresado()));
+            Assert.assertThat(exception.getMessage(), is(TemaDeReunion.ERROR_AGREGAR_INTERESADO));
         }
     }
 

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaParaRepasarActionItemsTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaParaRepasarActionItemsTest.java
@@ -17,7 +17,7 @@ public class TemaParaRepasarActionItemsTest {
         Minuta unaMinuta = helper.unaMinuta();
         TemaDeReunion unTemaDeReunion = helper.unTemaDeReunion();
 
-        TemaParaRepasarActionItems unTemaParaRepasarActionItems = new TemaParaRepasarActionItems(unaMinuta, unTemaDeReunion);
+        TemaParaRepasarActionItems unTemaParaRepasarActionItems = TemaParaRepasarActionItems.create(unaMinuta, unTemaDeReunion);
 
         assertThat(unTemaParaRepasarActionItems.getTitulo()).isEqualTo(unTemaDeReunion.getTitulo());
         assertThat(unTemaParaRepasarActionItems.getDescripcion()).isEqualTo(unTemaDeReunion.getDescripcion());
@@ -33,7 +33,7 @@ public class TemaParaRepasarActionItemsTest {
         Minuta unaMinuta = helper.unaMinuta();
         TemaDeReunion unTemaDeReunion = helper.unTemaDeReunion();
 
-        TemaParaRepasarActionItems unTemaParaRepasarActionItems = new TemaParaRepasarActionItems(unaMinuta, unTemaDeReunion);
+        TemaParaRepasarActionItems unTemaParaRepasarActionItems = TemaParaRepasarActionItems.create(unaMinuta, unTemaDeReunion);
 
         assertThat(unTemaParaRepasarActionItems.getTemasParaRepasar()).containsExactlyElementsOf(unaMinuta.getTemas());
     }

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaParaRepasarActionItemsTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaParaRepasarActionItemsTest.java
@@ -1,0 +1,40 @@
+package ar.com.kfgodel.temas.domain;
+
+import ar.com.kfgodel.temas.helpers.TestHelper;
+import convention.persistent.Minuta;
+import convention.persistent.TemaDeReunion;
+import convention.persistent.TemaParaRepasarActionItems;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TemaParaRepasarActionItemsTest {
+
+    private TestHelper helper = new TestHelper();
+
+    @Test
+    public void testUnTemaParaRepasarActionItemsTieneLoMismoQueElTemaAPartirDelCualFueCreado() {
+        Minuta unaMinuta = helper.unaMinuta();
+        TemaDeReunion unTemaDeReunion = helper.unTemaDeReunion();
+
+        TemaParaRepasarActionItems unTemaParaRepasarActionItems = new TemaParaRepasarActionItems(unaMinuta, unTemaDeReunion);
+
+        assertThat(unTemaParaRepasarActionItems.getTitulo()).isEqualTo(unTemaDeReunion.getTitulo());
+        assertThat(unTemaParaRepasarActionItems.getDescripcion()).isEqualTo(unTemaDeReunion.getDescripcion());
+        assertThat(unTemaParaRepasarActionItems.getObligatoriedad()).isEqualTo(unTemaDeReunion.getObligatoriedad());
+        assertThat(unTemaParaRepasarActionItems.getReunion()).isEqualTo(unTemaDeReunion.getReunion());
+        assertThat(unTemaParaRepasarActionItems.getDuracion()).isEqualTo(unTemaDeReunion.getDuracion());
+        assertThat(unTemaParaRepasarActionItems.getAutor()).isEqualTo(unTemaDeReunion.getAutor());
+        assertThat(unTemaParaRepasarActionItems.getInteresados()).containsExactlyElementsOf(unTemaDeReunion.getInteresados());
+    }
+
+    @Test
+    public void testUnTemaParaRepasarActionItemsTieneLosTemasDeMinutaDeLaMinutaAPartirDelCualFueCreado() {
+        Minuta unaMinuta = helper.unaMinuta();
+        TemaDeReunion unTemaDeReunion = helper.unTemaDeReunion();
+
+        TemaParaRepasarActionItems unTemaParaRepasarActionItems = new TemaParaRepasarActionItems(unaMinuta, unTemaDeReunion);
+
+        assertThat(unTemaParaRepasarActionItems.getTemasParaRepasar()).containsExactlyElementsOf(unaMinuta.getTemas());
+    }
+}

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/PersistentTestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/PersistentTestHelper.java
@@ -1,0 +1,70 @@
+package ar.com.kfgodel.temas.helpers;
+
+import ar.com.kfgodel.temas.application.Application;
+import convention.persistent.*;
+import convention.services.*;
+
+import java.util.List;
+
+public class PersistentTestHelper {
+    private TestHelper helper = new TestHelper();
+    private TemaService temaService;
+    private UsuarioService usuarioService;
+    private ReunionService reunionService;
+    private MinutaService minutaService;
+    private TemaGeneralService temaGeneralService;
+
+    public PersistentTestHelper(Application application) {
+        reunionService = application.getImplementationFor(ReunionService.class);
+        temaService = application.getImplementationFor(TemaService.class);
+        temaGeneralService = application.getImplementationFor(TemaGeneralService.class);
+        usuarioService = application.getImplementationFor(UsuarioService.class);
+        minutaService = application.getImplementationFor(MinutaService.class);
+    }
+
+    public Reunion crearUnaReunionConTemas() {
+        Reunion unaReunion = helper.unaReunion();
+        TemaDeReunion unTema = TemaDeReunionConDescripcion.create();
+        unTema.setReunion(unaReunion);
+        unaReunion.agregarTema(unTema);
+        reunionService.save(unaReunion);
+        return unaReunion;
+    }
+
+    public Reunion crearUnaReunion() {
+        Reunion reunion = helper.unaReunion();
+        reunionService.save(reunion);
+        return reunion;
+    }
+
+    public Reunion crearUnaReunionConTemaParaRellenarActionItems(){
+        Reunion unaReunion = helper.unaReunion();
+        TemaDeReunion temaParaRellenarActionItems = helper.unTemaDeReunionConTitulo(TemaParaRepasarActionItems.TITULO);
+        temaParaRellenarActionItems.setReunion(unaReunion);
+        unaReunion.agregarTema(temaParaRellenarActionItems);
+        reunionService.save(unaReunion);
+        return unaReunion;
+    }
+
+    public ActionItem crearActionItem() {
+        Usuario usuario = usuarioService.save(helper.unUsuario());
+        ActionItem actionItem = new ActionItem();
+        actionItem.setDescripcion("Tarea a realizar");
+        actionItem.setResponsables(List.of(usuario));
+        return actionItem;
+    }
+
+    public Reunion crearReunionMinuteada() {
+        Reunion reunion = helper.unaReunion();
+        reunion.agregarTema(helper.unTemaDeReunion());
+        reunion.marcarComoMinuteada();
+        return reunionService.save(reunion);
+    }
+
+    public Minuta crearMinutaConActionItem(Reunion unaReunion, ActionItem unActionItem) {
+        Minuta minuta = Minuta.create(unaReunion);
+        minuta.getTemas().get(0).setActionItems(List.of(unActionItem));
+        return minutaService.save(minuta);
+    }
+
+}

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/PersistentTestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/PersistentTestHelper.java
@@ -22,11 +22,12 @@ public class PersistentTestHelper {
         minutaService = application.getImplementationFor(MinutaService.class);
     }
 
-    public Reunion crearUnaReunionConTemas() {
+    public Reunion crearUnaReunionConTemasMinuteada() {
         Reunion unaReunion = helper.unaReunion();
         TemaDeReunion unTema = TemaDeReunionConDescripcion.create();
         unTema.setReunion(unaReunion);
         unaReunion.agregarTema(unTema);
+        unaReunion.setStatus(StatusDeReunion.CON_MINUTA);
         reunionService.save(unaReunion);
         return unaReunion;
     }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestConfig.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestConfig.java
@@ -28,23 +28,6 @@ public class TestConfig extends DevelopmentConfig {
     }
     @Override
     public Void inicializarDatos(){
-        if(getUsers().isEmpty()) {
-            Usuario unUser = Usuario.create("feche", "fecheromero", "123", "sarlnga","mail@10pines.com");
-            ApplicationOperation.createFor(getInjector())
-                    .insideATransaction()
-                    .taking(unUser)
-                    .convertingTo(Usuario.class)
-                    .applyingResultOf(Save::create)
-                    .convertTo(UserTo.class);
-
-            Usuario unUser2 = Usuario.create("sandro", "unSandro", "123", "sarlonga", "mail2@10pines.com");
-            ApplicationOperation.createFor(getInjector())
-                    .insideATransaction()
-                    .taking(unUser2)
-                    .convertingTo(Usuario.class)
-                    .applyingResultOf(Save::create)
-                    .convertTo(UserTo.class);
-        }
         return null;
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -5,6 +5,7 @@ import convention.persistent.*;
 import convention.rest.api.tos.UserTo;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * Created by sandro on 30/06/17.
@@ -24,13 +25,13 @@ public class TestHelper {
     }
 
     public TemaDeReunionConDescripcion unTemaAPartirDeUnTemaGeneral() {
-        Reunion reunion = Reunion.create(LocalDate.of(2017, 06, 26));
+        Reunion reunion = Reunion.create(LocalDate.of(2017, 6, 26));
         TemaGeneral temaGeneral = new TemaGeneral();
         return temaGeneral.generarTemaPara(reunion);
     }
 
     public Reunion unaReunion() {
-        return Reunion.create(LocalDate.of(2017, 06, 16));
+        return Reunion.create(LocalDate.of(2017, 6, 16));
     }
 
     public String unPino() {
@@ -104,6 +105,18 @@ public class TestHelper {
         return tema;
     }
 
+    public TemaParaRepasarActionItems unTemaParaRepasarActionItems() {
+        Usuario autor = unUsuario();
+        String titulo = TemaParaRepasarActionItems.TITULO;
+        String descripcion = unaDescripcion();
+        DuracionDeTema duracion = unaDuracion();
+        ObligatoriedadDeTema obligatoriedad = unaObligatoriedad();
+
+        TemaDeReunionConDescripcion temaPrevio = TemaDeReunionConDescripcion.create(autor, duracion, obligatoriedad, titulo, descripcion);
+        TemaParaRepasarActionItems tema = TemaParaRepasarActionItems.create(unaMinuta(), temaPrevio);
+        return tema;
+    }
+
     public UserTo unUserTo() {
         UserTo userTo = new UserTo();
         userTo.setName("un nombre");
@@ -118,14 +131,23 @@ public class TestHelper {
         Reunion unaReunion = unaReunion();
         unaReunion.agregarTema(unTemaDeReunion());
         unaReunion.cerrarVotacion();
-        return Minuta.create(unaReunion);
+        Minuta minuta = Minuta.create(unaReunion);
+        minuta.getTemas().get(0).setActionItems(List.of(unActionItem()));
+        return minuta;
     }
 
-    public Usuario unFeche(){
+    public Usuario unFeche() {
         return Usuario.create("feche", "fecheromero", "123", "sarlnga", "mail@10pines.com");
     }
 
-    public Usuario unSandro(){
+    public Usuario unSandro() {
         return Usuario.create("sandro", "unSandro", "123", "sarlonga", "mail2@10pines.com");
+    }
+
+    public ActionItem unActionItem() {
+        ActionItem actionItem = new ActionItem();
+        actionItem.setDescripcion("Una cosa para hacer");
+        actionItem.setResponsables(List.of(unUsuario(), otroUsuario()));
+        return actionItem;
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -105,15 +105,17 @@ public class TestHelper {
         return tema;
     }
 
-    public TemaParaRepasarActionItems unTemaParaRepasarActionItems() {
+    public TemaDeReunionConDescripcion unTemaParaRellenarConActionItems(){
         Usuario autor = unUsuario();
         String titulo = TemaParaRepasarActionItems.TITULO;
         String descripcion = unaDescripcion();
         DuracionDeTema duracion = unaDuracion();
         ObligatoriedadDeTema obligatoriedad = unaObligatoriedad();
 
-        TemaDeReunionConDescripcion temaPrevio = TemaDeReunionConDescripcion.create(autor, duracion, obligatoriedad, titulo, descripcion);
-        TemaParaRepasarActionItems tema = TemaParaRepasarActionItems.create(unaMinuta(), temaPrevio);
+        return TemaDeReunionConDescripcion.create(autor, duracion, obligatoriedad, titulo, descripcion);
+    }
+    public TemaParaRepasarActionItems unTemaParaRepasarActionItems() {
+        TemaParaRepasarActionItems tema = TemaParaRepasarActionItems.create(unaMinuta(), unTemaParaRellenarConActionItems());
         return tema;
     }
 

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -120,4 +120,12 @@ public class TestHelper {
         unaReunion.cerrarVotacion();
         return Minuta.create(unaReunion);
     }
+
+    public Usuario unFeche(){
+        return Usuario.create("feche", "fecheromero", "123", "sarlnga", "mail@10pines.com");
+    }
+
+    public Usuario unSandro(){
+        return Usuario.create("sandro", "unSandro", "123", "sarlonga", "mail2@10pines.com");
+    }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -113,4 +113,11 @@ public class TestHelper {
         userTo.setCreation("2019-01-01");
         return userTo;
     }
+
+    public Minuta unaMinuta() {
+        Reunion unaReunion = unaReunion();
+        unaReunion.agregarTema(unTemaDeReunion());
+        unaReunion.cerrarVotacion();
+        return Minuta.create(unaReunion);
+    }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/ReunionServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/ReunionServiceTest.java
@@ -2,13 +2,13 @@ package ar.com.kfgodel.temas.services;
 
 import ar.com.kfgodel.temas.helpers.TestHelper;
 import convention.persistent.*;
+import convention.services.Service;
 import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-public class ReunionServiceTest extends TemasServiceTest {
+public class ReunionServiceTest extends ServiceTest {
 
     private TestHelper helper = new TestHelper();
     private Reunion reunionConMinuta;

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/ReunionServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/ReunionServiceTest.java
@@ -1,30 +1,74 @@
 package ar.com.kfgodel.temas.services;
 
-import convention.persistent.Reunion;
+import ar.com.kfgodel.temas.helpers.TestHelper;
+import convention.persistent.*;
 import org.junit.Test;
 
-import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReunionServiceTest extends TemasServiceTest {
 
-    private Reunion reunionConMinutaDel24;
+    private TestHelper helper = new TestHelper();
+    private Reunion reunionConMinuta;
+    private ActionItem actionItem;
 
     @Override
     public void setUp() {
         super.setUp();
-        reunionConMinutaDel24 = crearReunionMinuteadaDe(LocalDate.of(2018, 12, 24));
+        reunionConMinuta = crearReunionMinuteada();
+        actionItem = crearActionItem();
+        crearMinutaConActionItem(reunionConMinuta, actionItem);
     }
 
-    private Reunion crearReunionMinuteadaDe(LocalDate fecha) {
-        Reunion reunion = Reunion.create(fecha);
+    private Reunion crearReunionMinuteada() {
+        Reunion reunion = helper.unaReunion();
+        reunion.agregarTema(helper.unTemaDeReunion());
         reunion.marcarComoMinuteada();
         return reunionService.save(reunion);
     }
 
+    private Minuta crearMinutaConActionItem(Reunion unaReunion, ActionItem unActionItem) {
+        Minuta minuta = Minuta.create(unaReunion);
+        minuta.getTemas().get(0).setActionItems(List.of(unActionItem));
+        return minutaService.save(minuta);
+    }
+
+    private ActionItem crearActionItem() {
+        Usuario usuario = usuarioService.save(helper.unUsuario());
+        ActionItem actionItem = new ActionItem();
+        actionItem.setDescripcion("Tarea a realizar");
+        actionItem.setResponsables(List.of(usuario));
+        return actionItem;
+    }
+
     @Test
     public void puedoPedirLaUltimaReunionCerrada() {
-        assertThat(reunionService.getUltimaReunion().getId()).isEqualTo(reunionConMinutaDel24.getId());
+        assertThat(reunionService.getUltimaReunion().getId()).isEqualTo(reunionConMinuta.getId());
+    }
+
+    @Test
+    public void seCarganLosActionItemsDeLaReunionAnteriorCuandoElTemaExiste() {
+        Reunion proximaReunion = reunionService.getProxima();
+        proximaReunion.agregarTema(helper.unTemaDeReunionConTitulo("Repasar action items de la root anterior"));
+        reunionService.cargarActionItemsDeLaUltimaMinutaSiExisteElTema(proximaReunion);
+        reunionService.save(proximaReunion);
+
+        TemaParaRepasarActionItems temaParaRepasarActionItems = (TemaParaRepasarActionItems) proximaReunion.getTemasPropuestos().get(0);
+        List<TemaDeMinuta> temasParaRepasar = temaParaRepasarActionItems.getTemasParaRepasar();
+        TemaDeMinuta temaConActionItem = temasParaRepasar.get(0);
+
+        assertThat(temasParaRepasar.size()).isEqualTo(1);
+        assertThat(temaConActionItem.getActionItems().get(0)).isEqualTo(actionItem);
+    }
+
+    @Test
+    public void noSeCarganLosActionItemsDeLaReunionAnteriorCuandoElTemaNoExiste(){
+        Reunion proximaReunion = reunionService.getProxima();
+        reunionService.cargarActionItemsDeLaUltimaMinutaSiExisteElTema(proximaReunion);
+        reunionService.save(proximaReunion);
+
+        assertThat(proximaReunion.getTemasPropuestos().size()).isEqualTo(0);
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/ReunionServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/ReunionServiceTest.java
@@ -1,46 +1,26 @@
 package ar.com.kfgodel.temas.services;
 
-import ar.com.kfgodel.temas.helpers.TestHelper;
-import convention.persistent.*;
-import convention.services.Service;
+import convention.persistent.ActionItem;
+import convention.persistent.Reunion;
+import convention.persistent.TemaDeMinuta;
+import convention.persistent.TemaParaRepasarActionItems;
 import org.junit.Test;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class ReunionServiceTest extends ServiceTest {
 
-    private TestHelper helper = new TestHelper();
     private Reunion reunionConMinuta;
     private ActionItem actionItem;
 
     @Override
     public void setUp() {
         super.setUp();
-        reunionConMinuta = crearReunionMinuteada();
-        actionItem = crearActionItem();
-        crearMinutaConActionItem(reunionConMinuta, actionItem);
-    }
-
-    private Reunion crearReunionMinuteada() {
-        Reunion reunion = helper.unaReunion();
-        reunion.agregarTema(helper.unTemaDeReunion());
-        reunion.marcarComoMinuteada();
-        return reunionService.save(reunion);
-    }
-
-    private Minuta crearMinutaConActionItem(Reunion unaReunion, ActionItem unActionItem) {
-        Minuta minuta = Minuta.create(unaReunion);
-        minuta.getTemas().get(0).setActionItems(List.of(unActionItem));
-        return minutaService.save(minuta);
-    }
-
-    private ActionItem crearActionItem() {
-        Usuario usuario = usuarioService.save(helper.unUsuario());
-        ActionItem actionItem = new ActionItem();
-        actionItem.setDescripcion("Tarea a realizar");
-        actionItem.setResponsables(List.of(usuario));
-        return actionItem;
+        reunionConMinuta = persistentHelper.crearReunionMinuteada();
+        actionItem = persistentHelper.crearActionItem();
+        persistentHelper.crearMinutaConActionItem(reunionConMinuta, actionItem);
     }
 
     @Test
@@ -64,7 +44,7 @@ public class ReunionServiceTest extends ServiceTest {
     }
 
     @Test
-    public void noSeCarganLosActionItemsDeLaReunionAnteriorCuandoElTemaNoExiste(){
+    public void noSeCarganLosActionItemsDeLaReunionAnteriorCuandoElTemaNoExiste() {
         Reunion proximaReunion = reunionService.getProxima();
         reunionService.cargarActionItemsDeLaUltimaMinutaSiExisteElTema(proximaReunion);
         reunionService.save(proximaReunion);

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/ServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/ServiceTest.java
@@ -1,0 +1,68 @@
+package ar.com.kfgodel.temas.services;
+
+import ar.com.kfgodel.dependencies.api.DependencyInjector;
+import ar.com.kfgodel.temas.apiRest.JettyIdentityAdapterTest;
+import ar.com.kfgodel.temas.apiRest.SecurityContextTest;
+import ar.com.kfgodel.temas.helpers.TestConfig;
+import ar.com.kfgodel.temas.helpers.TestHelper;
+import ar.com.kfgodel.temas.persistence.TestApplication;
+import convention.persistent.Usuario;
+import convention.rest.api.DuracionesResource;
+import convention.rest.api.ReunionResource;
+import convention.rest.api.TemaDeReunionResource;
+import convention.services.MinutaService;
+import convention.services.ReunionService;
+import convention.services.TemaService;
+import convention.services.UsuarioService;
+import org.junit.After;
+import org.junit.Before;
+
+import javax.ws.rs.core.SecurityContext;
+
+public abstract class ServiceTest {
+    private TestHelper helper = new TestHelper();
+
+    TestApplication app;
+
+    ReunionService reunionService;
+    MinutaService minutaService;
+    UsuarioService usuarioService;
+    TemaService temaService;
+
+    ReunionResource reunionResource;
+    DuracionesResource duracionResource;
+
+    SecurityContext testContextUserFeche;
+    TemaDeReunionResource temaDeReunionResource;
+    Long userId;
+    Long otherUserId;
+    Usuario otherUser;
+    Usuario user;
+
+    @Before
+    public void setUp() {
+        app = TestApplication.create(TestConfig.create());
+        app.start();
+        DependencyInjector injector = app.injector();
+        temaDeReunionResource = TemaDeReunionResource.create(injector);
+        duracionResource = DuracionesResource.create(injector);
+
+        reunionResource = ReunionResource.create(injector);
+        temaService = injector.getImplementationFor(TemaService.class).get();
+        usuarioService = injector.createInjected(UsuarioService.class);
+        minutaService = injector.getImplementationFor(MinutaService.class).get();
+        reunionService = injector.getImplementationFor(ReunionService.class).get();
+
+        user = usuarioService.save(helper.unFeche());
+        otherUser = usuarioService.save(helper.unSandro());
+
+        testContextUserFeche = new SecurityContextTest(usuarioService.getAll().get(0).getId());
+        userId = ((JettyIdentityAdapterTest) testContextUserFeche.getUserPrincipal()).getApplicationIdentification();
+        otherUserId = otherUser.getId();
+    }
+
+    @After
+    public void drop() {
+        app.clearServices();
+    }
+}

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/ServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/ServiceTest.java
@@ -3,6 +3,7 @@ package ar.com.kfgodel.temas.services;
 import ar.com.kfgodel.dependencies.api.DependencyInjector;
 import ar.com.kfgodel.temas.apiRest.JettyIdentityAdapterTest;
 import ar.com.kfgodel.temas.apiRest.SecurityContextTest;
+import ar.com.kfgodel.temas.helpers.PersistentTestHelper;
 import ar.com.kfgodel.temas.helpers.TestConfig;
 import ar.com.kfgodel.temas.helpers.TestHelper;
 import ar.com.kfgodel.temas.persistence.TestApplication;
@@ -20,7 +21,8 @@ import org.junit.Before;
 import javax.ws.rs.core.SecurityContext;
 
 public abstract class ServiceTest {
-    private TestHelper helper = new TestHelper();
+    TestHelper helper = new TestHelper();
+    PersistentTestHelper persistentHelper;
 
     TestApplication app;
 
@@ -59,6 +61,8 @@ public abstract class ServiceTest {
         testContextUserFeche = new SecurityContextTest(usuarioService.getAll().get(0).getId());
         userId = ((JettyIdentityAdapterTest) testContextUserFeche.getUserPrincipal()).getApplicationIdentification();
         otherUserId = otherUser.getId();
+
+        persistentHelper = new PersistentTestHelper(app);
     }
 
     @After

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/TemasServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/TemasServiceTest.java
@@ -16,6 +16,7 @@ import convention.rest.api.TemaDeReunionResource;
 import convention.rest.api.TemaGeneralResource;
 import convention.rest.api.tos.ReunionTo;
 import convention.rest.api.tos.TemaDeReunionTo;
+import convention.services.MinutaService;
 import convention.services.ReunionService;
 import convention.services.TemaService;
 import convention.services.UsuarioService;
@@ -39,6 +40,7 @@ public class TemasServiceTest {
     TestApplication app;
 
     ReunionService reunionService;
+    MinutaService minutaService;
     UsuarioService usuarioService;
     TemaService temaService;
     ReunionResource reunionResource;
@@ -63,6 +65,7 @@ public class TemasServiceTest {
         reunionResource = ReunionResource.create(injector);
         temaService = injector.getImplementationFor(TemaService.class).get();
         usuarioService = injector.createInjected(UsuarioService.class);
+        minutaService = injector.getImplementationFor(MinutaService.class).get();
         reunionService = injector.getImplementationFor(ReunionService.class).get();
 
         testContextUserFeche = new SecurityContextTest(usuarioService.getAll().get(0).getId());

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/TemasServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/TemasServiceTest.java
@@ -1,32 +1,16 @@
 package ar.com.kfgodel.temas.services;
 
 import ar.com.kfgodel.appbyconvention.operation.api.ApplicationOperation;
-import ar.com.kfgodel.dependencies.api.DependencyInjector;
 import ar.com.kfgodel.orm.api.operations.basic.Save;
 import ar.com.kfgodel.temas.acciones.CalculadorDeProximaFecha;
-import ar.com.kfgodel.temas.apiRest.JettyIdentityAdapterTest;
-import ar.com.kfgodel.temas.apiRest.SecurityContextTest;
-import ar.com.kfgodel.temas.application.Application;
-import ar.com.kfgodel.temas.helpers.TestConfig;
-import ar.com.kfgodel.temas.persistence.TestApplication;
 import convention.persistent.*;
-import convention.rest.api.DuracionesResource;
-import convention.rest.api.ReunionResource;
 import convention.rest.api.TemaDeReunionResource;
-import convention.rest.api.TemaGeneralResource;
 import convention.rest.api.tos.ReunionTo;
 import convention.rest.api.tos.TemaDeReunionTo;
-import convention.services.MinutaService;
-import convention.services.ReunionService;
-import convention.services.TemaService;
-import convention.services.UsuarioService;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.SecurityContext;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
@@ -35,52 +19,7 @@ import java.util.List;
 /**
  * Created by fede on 22/06/17.
  */
-public class TemasServiceTest {
-
-    TestApplication app;
-
-    ReunionService reunionService;
-    MinutaService minutaService;
-    UsuarioService usuarioService;
-    TemaService temaService;
-    ReunionResource reunionResource;
-    DuracionesResource duracionResource;
-    SecurityContext testContextUserFeche;
-    Long userId;
-    Long otherUserId;
-    Usuario otherUser;
-    Usuario user;
-    private TemaDeReunionResource temaDeReunionResource;
-    private TemaGeneralResource temaGeneralResource;
-
-    @Before
-    public void setUp() {
-        app = TestApplication.create(TestConfig.create());
-        app.start();
-        DependencyInjector injector = app.injector();
-        temaDeReunionResource = TemaDeReunionResource.create(injector);
-        duracionResource = DuracionesResource.create(injector);
-        temaGeneralResource = TemaGeneralResource.create(injector);
-
-        reunionResource = ReunionResource.create(injector);
-        temaService = injector.getImplementationFor(TemaService.class).get();
-        usuarioService = injector.createInjected(UsuarioService.class);
-        minutaService = injector.getImplementationFor(MinutaService.class).get();
-        reunionService = injector.getImplementationFor(ReunionService.class).get();
-
-        testContextUserFeche = new SecurityContextTest(usuarioService.getAll().get(0).getId());
-
-        userId = ((JettyIdentityAdapterTest) testContextUserFeche.getUserPrincipal()).getApplicationIdentification();
-        user = usuarioService.get(userId);
-        otherUser = usuarioService.getAll().stream().filter(userTo -> !userTo.getId().equals(userId)).findFirst().get();
-        otherUserId = otherUser.getId();
-    }
-
-    @After
-    public void drop() {
-        app.clearServices();
-    }
-
+public class TemasServiceTest extends ServiceTest {
 
     @Test
     public void alTraerUnaReunionConLaSeccionDeUnUsuarioNoTraeLosVotosDeOtrosSiLaReunionEstaPendiente() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/UserServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/UserServiceTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 /**
  * Created by fede on 05/07/17.
  */
-public class UserServiceTest extends TemasServiceTest {
+public class UserServiceTest extends ServiceTest {
 
     UserResource userResource;
     Reunion unaReunion;
@@ -30,7 +30,6 @@ public class UserServiceTest extends TemasServiceTest {
         unTema.agregarInteresado(user);
         unTema.setReunion(unaReunion);
         unaReunion.setTemasPropuestos(Arrays.asList(unTema));
-
     }
 
     @Test

--- a/backend/src/test/java/ar/com/kfgodel/temas/tos/TemaDeReunionToTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/tos/TemaDeReunionToTest.java
@@ -7,6 +7,7 @@ import ar.com.kfgodel.temas.helpers.TestHelper;
 import ar.com.kfgodel.temas.persistence.TestApplication;
 import ar.com.kfgodel.transformbyconvention.api.TypeTransformer;
 import convention.persistent.*;
+import convention.rest.api.tos.TemaParaRepasarActionItemsTo;
 import convention.rest.api.tos.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,6 +103,55 @@ public class TemaDeReunionToTest {
         assertThat(convertEnumToString(tema.getDuracion())).isEqualTo(temaTo.getDuracion());
         assertThat(convertEnumToString(tema.getObligatoriedad())).isEqualTo(temaTo.getObligatoriedad());
         assertThat(tema.propuestas().stream().map(PropuestaDePinoARoot::pino)).containsExactly(unPino, otroPino);
+    }
+
+    @Test
+    public void testSePuedeConvertirDeUnTemaParaRepasarActionItemsTo() {
+        Usuario unAutor = helper.unUsuario();
+        String unaDuracion = convertEnumToString(TemaParaProponerPinosARoot.DURACION);
+        String unaObligatoriedad = convertEnumToString(TemaParaProponerPinosARoot.OBLIGATORIEDAD);
+        String unTitulo = TemaParaRepasarActionItems.TITULO;
+
+        TemaDeMinutaTo temadeMinutaTo = new TemaDeMinutaTo();
+        temadeMinutaTo.setFueTratado(true);
+        UserTo unUsuario = new UserTo();
+        unUsuario.setName("Jorge");
+        ActionItemTo unActionItem = new ActionItemTo();
+        unActionItem.setDescripcion("Una cosa para hacer");
+        unActionItem.setResponsables(List.of(unUsuario));
+        temadeMinutaTo.setActionItems(List.of(unActionItem));
+
+        TemaParaRepasarActionItemsTo temaTo =
+                TemaParaRepasarActionItemsTo.create(unAutor, unaDuracion, unaObligatoriedad, unTitulo, List.of(temadeMinutaTo));
+
+        TemaParaRepasarActionItems tema = (TemaParaRepasarActionItems)
+                baseConverter.transformTo(TemaDeReunion.class, temaTo);
+
+        assertThat(tema.getTitulo()).isEqualTo(temaTo.getTitulo());
+        assertThat(tema.getDescripcion()).isEqualTo(temaTo.getDescripcion());
+        assertThat(convertEnumToString(tema.getDuracion())).isEqualTo(temaTo.getDuracion());
+        assertThat(convertEnumToString(tema.getObligatoriedad())).isEqualTo(temaTo.getObligatoriedad());
+        assertThat(tema.getTemasParaRepasar().get(0).getActionItems().get(0).getDescripcion())
+                .isEqualTo("Una cosa para hacer");
+        assertThat(tema.getTemasParaRepasar().get(0).getActionItems().get(0).getResponsables().get(0).getName())
+                .isEqualTo("Jorge");
+    }
+
+    @Test
+    public void testSePuedeConvertirAUnTemaParaRepasarActionItemsTo() {
+        TemaParaRepasarActionItems tema = helper.unTemaParaRepasarActionItems();
+
+        TemaParaRepasarActionItemsTo temaTo = (TemaParaRepasarActionItemsTo)
+                baseConverter.transformTo(TemaDeReunionTo.class, tema);
+
+        assertThat(temaTo.getIdDeAutor()).isEqualTo(tema.getAutor().getId());
+        assertThat(temaTo.getTitulo()).isEqualTo(tema.getTitulo());
+        assertThat(temaTo.getDuracion()).isEqualTo(convertEnumToString(tema.getDuracion()));
+        assertThat(temaTo.getObligatoriedad()).isEqualTo(convertEnumToString(tema.getObligatoriedad()));
+        assertThat(temaTo.getTemasParaRepasar().get(0).getActionItems().get(0).getDescripcion())
+                .isEqualTo("Una cosa para hacer");
+        assertThat(temaTo.getTemasParaRepasar().get(0).getActionItems().get(0).getResponsables().get(0).getName())
+                .isEqualTo("jorge");
     }
 
     private String convertEnumToString(Object enumValue) {


### PR DESCRIPTION
Implementa el backend para cargar automáticamente los action items de la ultima minuta. Crea un nuevo tema TemaParaRepasarActionItems, con tests de dominio, servicios y resources.

También reorganiza la estructura de los tests y helpers para evitar problemas de limpieza de DB entre tests, tests repetidos y factories duplicados.