### PR TITLE
Fix de error al cambiar la fecha de una reunión con temas

### DIFF
--- a/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
@@ -1,6 +1,7 @@
 package convention.rest.api.tos;
 
 import ar.com.kfgodel.appbyconvention.tos.PersistableToSupport;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import convention.persistent.TemaDeReunion;
@@ -16,6 +17,7 @@ import java.util.List;
         @JsonSubTypes.Type(value = TemaParaProponerPinosARootTo.class, name = "proponerPinos"),
         @JsonSubTypes.Type(value = TemaDeReunionConDescripcionTo.class, name = "conDescripcion")
 })
+@JsonIgnoreProperties({"usuarioActual"})
 public class TemaDeReunionTo extends PersistableToSupport {
     @CopyFromAndTo(TemaDeReunion.duracion_FIELD)
     private String duracion;


### PR DESCRIPTION
Problema:
Cuando se le quiere cambiar la fecha a una reunión que tiene algún tema se obtiene un bad request al hacer el PUT request que actualiza la reunión.

Causa:
El PUT request tiene una propiedad `usuarioActual` que no reconoce el backend al deserializar el JSON.
Esta propiedad se ignoraba con una annotation en la clase `TemaTo` que se perdió cuando se eliminó esta clase.

Fix:
Se agrega dicha annotation a `TemaDeReunionTo`