### PR TITLE
Cambia el título del tema para repasar action items

### DIFF
--- a/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
+++ b/backend/src/main/java/convention/persistent/TemaParaRepasarActionItems.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Entity
 public class TemaParaRepasarActionItems extends TemaDeReunion {
 
-    public static final String TITULO = "Repasar action items de la root anterior";
+    public static final String TITULO = "Ver action items anteriores";
     public static final String temasParaRepasar_FIELD = "temasParaRepasar";
 
     @OneToMany(fetch = FetchType.EAGER)

--- a/backend/src/test/java/ar/com/kfgodel/temas/services/ReunionServiceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/services/ReunionServiceTest.java
@@ -33,7 +33,7 @@ public class ReunionServiceTest extends ServiceTest {
     @Test
     public void seCarganLosActionItemsDeLaReunionAnteriorCuandoElTemaExiste() {
         Reunion proximaReunion = reunionService.getProxima();
-        proximaReunion.agregarTema(helper.unTemaDeReunionConTitulo("Repasar action items de la root anterior"));
+        proximaReunion.agregarTema(helper.unTemaDeReunionConTitulo("Ver action items anteriores"));
         reunionService.cargarActionItemsDeLaUltimaMinutaSiExisteElTema(proximaReunion);
         reunionService.save(proximaReunion);
 


### PR DESCRIPTION
Hace que se carguen las action items en el tema que tiene el título "Ver action items anteriores" en vez de "Repasar action items de la root anterior"