### PR TITLE
Agrega a los temas de reunión una primera propuesta

### DIFF
--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -23,6 +23,7 @@ public abstract class TemaDeReunion extends Tema {
     public static final String interesados_FIELD = "interesados";
     public static final String obligatoriedad_FIELD = "obligatoriedad";
     public static final String temaGenerador_FIELD = "temaGenerador";
+    public static final String primeraPropuesta_FIELD = "primeraPropuesta";
     public static final String ERROR_AGREGAR_INTERESADO = "No se puede agregar un interesado a un tema obligatorio";
     @ManyToOne
     private Reunion reunion;
@@ -185,6 +186,6 @@ public abstract class TemaDeReunion extends Tema {
     }
 
     public TemaDeReunion getPrimeraPropuesta() {
-        return primeraPropuesta;
+        return Optional.ofNullable(primeraPropuesta).orElse(this);
     }
 }

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -34,6 +34,8 @@ public abstract class TemaDeReunion extends Tema {
     private ObligatoriedadDeTema obligatoriedad;
     @ManyToOne
     private TemaGeneral temaGenerador;
+    @ManyToOne
+    private TemaDeReunion primeraPropuesta;
 
     public ObligatoriedadDeTema getObligatoriedad() {
         return obligatoriedad;
@@ -176,5 +178,13 @@ public abstract class TemaDeReunion extends Tema {
 
     public Boolean esParaRepasarActionItems() {
         return false;
+    }
+
+    public void setPrimeraPropuesta(TemaDeReunion unTemaDeReunion) {
+        primeraPropuesta = unTemaDeReunion;
+    }
+
+    public TemaDeReunion getPrimeraPropuesta() {
+        return primeraPropuesta;
     }
 }

--- a/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
@@ -40,6 +40,8 @@ public class TemaDeReunionTo extends PersistableToSupport {
     private List<Long> idsDeInteresados;
     @CopyFromAndTo(TemaDeReunion.obligatoriedad_FIELD)
     private String obligatoriedad;
+    @CopyFrom(TemaDeReunion.primeraPropuesta_FIELD)
+    private Long idDePrimeraPropuesta;
 
     public String getAutor() {
       return autor;
@@ -119,5 +121,13 @@ public class TemaDeReunionTo extends PersistableToSupport {
 
     public void setUltimoModificador(String idDeUltimoModificador) {
       this.ultimoModificador = idDeUltimoModificador;
+    }
+
+    public Long getIdDePrimeraPropuesta() {
+        return idDePrimeraPropuesta;
+    }
+
+    public void setIdDePrimeraPropuesta(Long idDePrimeraPropuesta) {
+        this.idDePrimeraPropuesta = idDePrimeraPropuesta;
     }
 }

--- a/backend/src/main/java/convention/rest/api/tos/TemaEnCreacionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaEnCreacionTo.java
@@ -29,6 +29,9 @@ public class TemaEnCreacionTo {
     @CopyTo(TemaDeReunion.obligatoriedad_FIELD)
     private String obligatoriedad;
 
+    @CopyTo(TemaDeReunion.primeraPropuesta_FIELD)
+    private Long idDePrimeraPropuesta;
+
     public String getDuracion() {
         return duracion;
     }
@@ -77,4 +80,11 @@ public class TemaEnCreacionTo {
         this.descripcion = descripcion;
     }
 
+    public void setIdDePrimeraPropuesta(Long idDePrimeraPropuesta) {
+        this.idDePrimeraPropuesta = idDePrimeraPropuesta;
+    }
+
+    public Long getIdDePrimeraPropuesta() {
+        return idDePrimeraPropuesta;
+    }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
@@ -160,7 +160,11 @@ public abstract class ResourceTest {
     }
 
     TemaDeReunionTo convertirATo(TemaDeReunion unTemaDeReunion) {
-        return getTypeTransformer().transformTo(TemaDeReunionTo.class, unTemaDeReunion);
+        return convertirA(unTemaDeReunion, TemaDeReunionTo.class);
+    }
+
+    <T> T convertirA(Object unObjeto, Class<T> unaClaseDestino) {
+        return getTypeTransformer().transformTo(unaClaseDestino, unObjeto);
     }
 
     String convertirAJsonString(Object unObjeto) throws JsonProcessingException {

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
@@ -46,7 +46,7 @@ public abstract class ResourceTest {
     ReunionService reunionService;
     MinutaService minutaService;
     TemaGeneralService temaGeneralService;
-    TestHelper helper = new TestHelper();
+    TestHelper helper;
     PersistentTestHelper persistentHelper;
     private HttpClient client;
 
@@ -98,6 +98,8 @@ public abstract class ResourceTest {
         temaGeneralService = getApplication().getImplementationFor(TemaGeneralService.class);
         usuarioService = getApplication().getImplementationFor(UsuarioService.class);
         minutaService = getApplication().getImplementationFor(MinutaService.class);
+
+        helper = getInjector().createInjected(TestHelper.class);
         usuarioService.save(helper.unFeche());
         usuarioService.save(helper.unSandro());
 

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -112,6 +112,19 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         assertThat(temaCreado.getPrimeraPropuesta()).isEqualTo(temaCreado);
     }
 
+    @Test
+    public void testGetDeTemasDeReunionContieneElIdDeLaPrimeraPropuesta() throws IOException {
+        Reunion unaReunion = reunionService.save(helper.unaReunion());
+        TemaDeReunion unTema = helper.unTemaDeReunion();
+        unTema.setReunion(unaReunion);
+        unTema = temaService.save(unTema);
+
+        HttpResponse response = makeGetRequest("temas/" + unTema.getId());
+
+        JSONObject jsonResponse = new JSONObject(getResponseBody(response));
+        assertThat(jsonResponse.getLong("idDePrimeraPropuesta")).isEqualTo(unTema.getPrimeraPropuesta().getId());
+    }
+
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {
         TemaDeReunionConDescripcion unTemaConDescripcion = new TemaDeReunionConDescripcion();
         temaService.save(unTemaConDescripcion);

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -1,10 +1,6 @@
 package ar.com.kfgodel.temas.apiRest;
 
-import ar.com.kfgodel.temas.helpers.TestHelper;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import convention.persistent.*;
-import convention.rest.api.tos.TemaDeReunionTo;
 import convention.rest.api.tos.TemaEnCreacionTo;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -90,6 +86,30 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         TemaDeReunion temaActualizado = temaService.get(idDelTema);
         assertThatResponseStatusCodeIs(response, HttpStatus.SC_CONFLICT);
         assertThat(temaActualizado.getTitulo()).isEqualTo(tituloDelTema);
+    }
+
+    @Test
+    public void testUnTemaSeCreaConUnaPrimeraPropuesta() throws IOException {
+        TemaDeReunionConDescripcion unTemaDeReunion = crearUnTemaDeReunionConDescripcion();
+        TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo();
+        unTemaEnCreacionTo.setIdDePrimeraPropuesta(unTemaDeReunion.getId());
+
+        HttpResponse response = makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
+
+        Long idDelTemaCreado = new JSONObject(getResponseBody(response)).getLong("id");
+        TemaDeReunion temaCreado = temaService.get(idDelTemaCreado);
+        assertThat(temaCreado.getPrimeraPropuesta()).isEqualTo(unTemaDeReunion);
+    }
+
+    @Test
+    public void testUnTemaSeCreaConsigoMismoComoPrimeraPropuestaSiNoSeEspecificaUna() throws IOException {
+        TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo();
+        unTemaEnCreacionTo.setIdDePrimeraPropuesta(null);
+
+        makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
+
+        TemaDeReunion temaCreado = temaService.getAll().get(0);
+        assertThat(temaCreado.getPrimeraPropuesta()).isEqualTo(temaCreado);
     }
 
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static junit.framework.TestCase.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 
 /**
@@ -191,5 +192,15 @@ public class TemaDeReunionTest {
         tema.setTitulo("otro titulo");
 
         Assert.assertTrue(tema.fueModificado());
+    }
+
+    @Test
+    public void test20LosTemasTienenUnaPrimeraPropuesta() {
+        TemaDeReunion unTema = helper.unTemaDeReunion();
+        TemaDeReunion otroTema = helper.unTemaDeReunion();
+
+        unTema.setPrimeraPropuesta(otroTema);
+
+        assertThat(unTema.getPrimeraPropuesta()).isEqualTo(otroTema);
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -1,10 +1,13 @@
 package ar.com.kfgodel.temas.helpers;
 
 import ar.com.kfgodel.temas.domain.TemaParaProponerPinosARootTest;
+import ar.com.kfgodel.transformbyconvention.api.TypeTransformer;
 import convention.persistent.*;
 import convention.rest.api.tos.ActionItemTo;
+import convention.rest.api.tos.TemaEnCreacionTo;
 import convention.rest.api.tos.UserTo;
 
+import javax.inject.Inject;
 import java.time.LocalDate;
 import java.util.Arrays;
 
@@ -12,6 +15,9 @@ import java.util.Arrays;
  * Created by sandro on 30/06/17.
  */
 public class TestHelper {
+
+    @Inject
+    TypeTransformer typeTransformer;
 
     public TemaDeReunionConDescripcion unTemaObligatorio() {
         TemaDeReunionConDescripcion tema = TemaDeReunionConDescripcion.create();
@@ -163,5 +169,17 @@ public class TestHelper {
 
     public TemaGeneral unTemaGeneral() {
         return new TemaGeneral();
+    }
+
+    public TemaEnCreacionTo unTemaEnCreacionTo() {
+        TemaEnCreacionTo unTemaEnCreacionTo = new TemaEnCreacionTo();
+        unTemaEnCreacionTo.setTitulo(unTitulo());
+        unTemaEnCreacionTo.setDescripcion(unaDescripcion());
+        unTemaEnCreacionTo.setObligatoriedad(convertirA(unaObligatoriedad(), String.class));
+        return unTemaEnCreacionTo;
+    }
+
+    private <T> T convertirA(Object unObjeto, Class<T> unaClaseDestino) {
+        return typeTransformer.transformTo(unaClaseDestino, unObjeto);
     }
 }


### PR DESCRIPTION
La primera propuesta es un tema de reunión que corresponde a la primera vez que se propuso el tema. Cuando un tema se crea su primera propuesta es él mismo. Todos los temas que sean una re-propuesta de este tema lo van a tener como primera propuesta.

El objetivo de tener esto es poder identificar a las re-propuestas de un tema sin importar a partir de cuál de todas la propuestas fue creado. Por ejemplo, supongamos que tenemos un tema `T` que se propone por primera vez, un tema `T1` que es una re-propuesta de `T` y dos temas `T2` y `T3` que son ambos re-propuestas de `T1`:
```
T -- T1 -- T2
        \
         T3
```
La primera propuesta de todos estos temas debería ser `T`. Con esto podemos re-proponer temas usando el mismo endpoint que se usa para crearlos, evitar que se vuelva a proponer el mismo tema varias veces a partir de distintas re-propuestas y va a facilitar la implementación de la historia para conocer la antigüedad de un tema que se re-propone.