### PR TITLE
Hace que se muestre correctamente el último minuteador de una minuta

### DIFF
--- a/backend/src/main/java/ar/com/kfgodel/temas/acciones/CrearMinuta.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/acciones/CrearMinuta.java
@@ -5,6 +5,7 @@ import ar.com.kfgodel.orm.api.operations.TransactionOperation;
 import ar.com.kfgodel.orm.api.operations.basic.Save;
 import convention.persistent.Minuta;
 import convention.persistent.Reunion;
+import convention.persistent.Usuario;
 
 /**
  * Created by sandro on 07/07/17.
@@ -12,10 +13,12 @@ import convention.persistent.Reunion;
 public class CrearMinuta implements TransactionOperation<Minuta> {
 
     private Reunion reunion;
+    private Usuario minuteador;
 
-    public static CrearMinuta create(Reunion reunion){
+    public static CrearMinuta create(Reunion reunion, Usuario unMinuteador){
         CrearMinuta accion = new CrearMinuta();
         accion.reunion = reunion;
+        accion.minuteador = unMinuteador;
         return accion;
     }
 
@@ -27,6 +30,7 @@ public class CrearMinuta implements TransactionOperation<Minuta> {
     @Override
     public Minuta applyWithTransactionOn(TransactionContext transactionContext) {
         Minuta nuevaMinuta = Minuta.create(reunion);
+        nuevaMinuta.setMinuteador(minuteador);
         Save.create(nuevaMinuta).applyWithTransactionOn(transactionContext);
         return nuevaMinuta;
     }

--- a/backend/src/main/java/convention/rest/api/MinutaResource.java
+++ b/backend/src/main/java/convention/rest/api/MinutaResource.java
@@ -25,8 +25,9 @@ public class MinutaResource{
     private ResourceHelper resourceHelper;
     @GET
     @Path("reunion/{reunionId}")
-    public MinutaTo getParaReunion(@PathParam("reunionId") Long id ){
-        Minuta minuta = minutaService.getFromReunion(id);
+    public MinutaTo getParaReunion(@PathParam("reunionId") Long id, @Context SecurityContext securityContext){
+        Usuario usuarioActual = getResourceHelper().usuarioActual(securityContext);
+        Minuta minuta = minutaService.getOrCreateForReunion(id, usuarioActual);
         minutaService.update(minuta);
         return getResourceHelper().convertir(minuta, MinutaTo.class);
     }

--- a/backend/src/main/java/convention/rest/api/TemaDeMinutaResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeMinutaResource.java
@@ -1,12 +1,18 @@
 package convention.rest.api;
 
 import ar.com.kfgodel.dependencies.api.DependencyInjector;
+import convention.persistent.Minuta;
 import convention.persistent.TemaDeMinuta;
+import convention.persistent.Usuario;
 import convention.rest.api.tos.TemaDeMinutaTo;
+import convention.services.MinutaService;
+import convention.services.Service;
 import convention.services.TemaDeMinutaService;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
 
 /**
  * Created by fede on 07/07/17.
@@ -16,10 +22,13 @@ import javax.ws.rs.*;
 @Consumes("application/json")
 public class TemaDeMinutaResource{
 
-        @Inject
-    TemaDeMinutaService temaDeMinutaService;
+    @Inject
+    private TemaDeMinutaService temaDeMinutaService;
+    @Inject
+    private MinutaService minutaService;
 
-        private ResourceHelper resourceHelper;
+    private ResourceHelper resourceHelper;
+
     @GET
     @Path("/{resourceId}")
     public TemaDeMinutaTo getSingle(@PathParam("resourceId") Long id) {
@@ -28,9 +37,12 @@ public class TemaDeMinutaResource{
     }
     @PUT
     @Path("/{resourceId}")
-    public TemaDeMinutaTo update(TemaDeMinutaTo newState, @PathParam("resourceId") Long id) {
-        TemaDeMinuta temaDeMinutaActualizada = temaDeMinutaService.update( getResourceHelper().convertir(newState, TemaDeMinuta.class));
-        return  getResourceHelper().convertir(temaDeMinutaActualizada, TemaDeMinutaTo.class);
+    public TemaDeMinutaTo update(TemaDeMinutaTo newState, @PathParam("resourceId") Long id, @Context SecurityContext securityContext) {
+        TemaDeMinuta temaDeMinuta = temaDeMinutaService.update(getResourceHelper().convertir(newState, TemaDeMinuta.class));
+        Minuta minutaDelTema = minutaService.get(temaDeMinuta.getMinuta().getId());
+        minutaDelTema.setMinuteador(getResourceHelper().usuarioActual(securityContext));
+        minutaService.update(minutaDelTema);
+        return  getResourceHelper().convertir(temaDeMinuta, TemaDeMinutaTo.class);
     }
     public static TemaDeMinutaResource create(DependencyInjector appInjector) {
         TemaDeMinutaResource temaDeMinutaResource = new TemaDeMinutaResource();

--- a/backend/src/main/java/convention/services/ReunionService.java
+++ b/backend/src/main/java/convention/services/ReunionService.java
@@ -42,8 +42,7 @@ public class ReunionService extends Service<Reunion> {
 
   @Override
   public void delete(Long id) {
-    Minuta minuta = minutaService.getFromReunion(id);
-    minutaService.delete(minuta.getId());
+    minutaService.getForReunion(id).ifPresent(minutaService::delete);
     super.delete(id);
   }
 

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/MinutaResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/MinutaResourceTest.java
@@ -2,10 +2,15 @@ package ar.com.kfgodel.temas.apiRest;
 
 import convention.persistent.Minuta;
 import convention.persistent.Reunion;
+import convention.persistent.TemaDeMinuta;
 import convention.persistent.Usuario;
+import convention.rest.api.tos.TemaDeMinutaTo;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,5 +38,24 @@ public class MinutaResourceTest extends ResourceTest {
 
         Minuta minutaCreada = minutaService.getUltimaMinuta().get();
         assertThat(minutaCreada.getMinuteador()).isNotEqualTo(getAuthenticatedUser());
+    }
+
+    @Test
+    public void testCuandoUnUsuarioModificaUnTemaDeMinutaPasaASerElMinuteadorDeElla() throws IOException {
+        Reunion unaReunion = reunionService.save(helper.unaReunionMinuteadaConTemas());
+        Minuta unaMinuta = Minuta.create(unaReunion);
+        Usuario unUsuario = usuarioService.save(helper.unUsuario());
+        unaMinuta.setMinuteador(unUsuario);
+        unaMinuta = minutaService.save(unaMinuta);
+
+        TemaDeMinuta unTemaDeMinuta = unaMinuta.getTemas().get(0);
+        unTemaDeMinuta.setActionItems(new ArrayList<>());
+        TemaDeMinutaTo toDelTemaDeMinuta = convertirATo(unTemaDeMinuta);
+        HttpResponse response =
+                makeJsonPutRequest("temaDeMinuta/" + unTemaDeMinuta.getId(), convertirAJsonString(toDelTemaDeMinuta));
+
+        Minuta minutaActualizada = minutaService.get(unaMinuta.getId());
+        assertThatResponseStatusCodeIs(response, HttpStatus.SC_OK);
+        assertThat(minutaActualizada.getMinuteador()).isEqualTo(getAuthenticatedUser());
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/MinutaResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/MinutaResourceTest.java
@@ -1,0 +1,37 @@
+package ar.com.kfgodel.temas.apiRest;
+
+import convention.persistent.Minuta;
+import convention.persistent.Reunion;
+import convention.persistent.Usuario;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MinutaResourceTest extends ResourceTest {
+
+    @Test
+    public void testCuandoUnUsuarioCreaUnaMinutaPasaASerSuMinuteador() throws IOException {
+        Reunion unaReunion = reunionService.save(helper.unaReunionCerrada());
+
+        makeGetRequest("minuta/reunion/" + unaReunion.getId());
+
+        Minuta minutaCreada = minutaService.getUltimaMinuta().get();
+        assertThat(minutaCreada.getMinuteador()).isEqualTo(getAuthenticatedUser());
+    }
+
+    @Test
+    public void testCuandoUnUsuarioHaceGetDeUnaMinutaNoPasaASerSuMinuteador() throws IOException {
+        Reunion unaReunion = reunionService.save(helper.unaReunionMinuteada());
+        Minuta unaMinuta = Minuta.create(unaReunion);
+        Usuario unUsuario = usuarioService.save(helper.unUsuario());
+        unaMinuta.setMinuteador(unUsuario);
+        minutaService.save(unaMinuta);
+
+        makeGetRequest("minuta/reunion/" + unaReunion.getId());
+
+        Minuta minutaCreada = minutaService.getUltimaMinuta().get();
+        assertThat(minutaCreada.getMinuteador()).isNotEqualTo(getAuthenticatedUser());
+    }
+}

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
@@ -4,7 +4,6 @@ import ar.com.kfgodel.dependencies.api.DependencyInjector;
 import ar.com.kfgodel.temas.application.Application;
 import ar.com.kfgodel.temas.application.TemasApplication;
 import ar.com.kfgodel.temas.config.AuthenticatedTestConfig;
-import ar.com.kfgodel.temas.config.TemasConfiguration;
 import ar.com.kfgodel.temas.exceptions.TypeTransformerException;
 import ar.com.kfgodel.transformbyconvention.api.TypeTransformer;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -12,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import convention.persistent.TemaDeReunion;
 import ar.com.kfgodel.temas.helpers.PersistentTestHelper;
 import ar.com.kfgodel.temas.helpers.TestHelper;
+import convention.persistent.Usuario;
 import convention.rest.api.ReunionResource;
 import convention.rest.api.TemaDeReunionResource;
 import convention.rest.api.tos.TemaDeReunionTo;
@@ -41,6 +41,7 @@ public abstract class ResourceTest {
 
     private static Thread serverThread;
     private static TemasApplication application;
+    private static AuthenticatedTestConfig applicationConfig;
     TemaService temaService;
     UsuarioService usuarioService;
     ReunionService reunionService;
@@ -53,7 +54,7 @@ public abstract class ResourceTest {
     @BeforeClass
     public static void applicationSetUp() {
         serverThread = new Thread(() -> {
-            TemasConfiguration applicationConfig = new AuthenticatedTestConfig();
+            applicationConfig = new AuthenticatedTestConfig();
             application = (TemasApplication) TemasApplication.create(applicationConfig);
             application.start();
         });
@@ -168,5 +169,9 @@ public abstract class ResourceTest {
     private TypeTransformer getTypeTransformer() {
         return getInjector().getImplementationFor(TypeTransformer.class)
                 .orElseThrow(() -> new TypeTransformerException("no se ha injectado ningún TypeTransformer"));
+    }
+
+    Usuario getAuthenticatedUser() {
+        return usuarioService.get(applicationConfig.getAuthenticatedUserId());
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ResourceTest.java
@@ -8,12 +8,14 @@ import ar.com.kfgodel.temas.exceptions.TypeTransformerException;
 import ar.com.kfgodel.transformbyconvention.api.TypeTransformer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import convention.persistent.TemaDeMinuta;
 import convention.persistent.TemaDeReunion;
 import ar.com.kfgodel.temas.helpers.PersistentTestHelper;
 import ar.com.kfgodel.temas.helpers.TestHelper;
 import convention.persistent.Usuario;
 import convention.rest.api.ReunionResource;
 import convention.rest.api.TemaDeReunionResource;
+import convention.rest.api.tos.TemaDeMinutaTo;
 import convention.rest.api.tos.TemaDeReunionTo;
 import convention.services.*;
 import org.apache.http.HttpResponse;
@@ -160,6 +162,10 @@ public abstract class ResourceTest {
 
     TemaDeReunionTo convertirATo(TemaDeReunion unTemaDeReunion) {
         return getTypeTransformer().transformTo(TemaDeReunionTo.class, unTemaDeReunion);
+    }
+
+    TemaDeMinutaTo convertirATo(TemaDeMinuta unTemaDeMinuta) {
+        return getTypeTransformer().transformTo(TemaDeMinutaTo.class, unTemaDeMinuta);
     }
 
     String convertirAJsonString(Object unObjeto) throws JsonProcessingException {

--- a/backend/src/test/java/ar/com/kfgodel/temas/config/AuthenticatedTestConfig.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/config/AuthenticatedTestConfig.java
@@ -2,6 +2,7 @@ package ar.com.kfgodel.temas.config;
 
 import ar.com.kfgodel.temas.helpers.TestConfig;
 import ar.com.kfgodel.webbyconvention.api.auth.WebCredential;
+import convention.rest.api.tos.UserTo;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -10,6 +11,10 @@ public class AuthenticatedTestConfig extends TestConfig {
 
     @Override
     public Function<WebCredential, Optional<Object>> autenticador() {
-        return webCredential -> Optional.of(getUsers().get(0).getId());
+        return webCredential -> Optional.of(getAuthenticatedUserId());
+    }
+
+    public Long getAuthenticatedUserId() {
+        return getUsers().stream().map(UserTo::getId).min(Long::compareTo).get();
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -176,4 +176,12 @@ public class TestHelper {
         unaReunion.marcarComoMinuteada();
         return unaReunion;
     }
+
+    public Reunion unaReunionMinuteadaConTemas() {
+        Reunion unaReunion = unaReunion();
+        unaReunion.agregarTema(unTemaDeReunion());
+        unaReunion.cerrarVotacion();
+        unaReunion.marcarComoMinuteada();
+        return unaReunion;
+    }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -164,4 +164,16 @@ public class TestHelper {
     public TemaGeneral unTemaGeneral() {
         return new TemaGeneral();
     }
+
+    public Reunion unaReunionCerrada() {
+        Reunion unaReunion = unaReunion();
+        unaReunion.cerrarVotacion();
+        return unaReunion;
+    }
+
+    public Reunion unaReunionMinuteada() {
+        Reunion unaReunion = unaReunionCerrada();
+        unaReunion.marcarComoMinuteada();
+        return unaReunion;
+    }
 }


### PR DESCRIPTION
Cuando se creaba una minuta no se mostraba a ningún usuario como último minuteador. Este se ponía una vez que algún usuario modificaba a los asistentes de una minuta. Tampoco se cambiaba cuando alguien modificaba un tema de la minuta.

Este PR hace que cuando usuario cierra la votación (y por ende crea la minuta) pase a ser último minuteador. Además, cada vez que alguien modifica un tema de la minuta pasa a ser también el último minuteador.

Historia: https://trello.com/c/VGXyPhQM