### PR TITLE
Corrige errores que se introdujeron con las primeras propuestas

### DIFF
--- a/backend/src/main/java/ar/com/kfgodel/temas/acciones/ConvertirRePropuestasAPrimerasPropuestas.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/acciones/ConvertirRePropuestasAPrimerasPropuestas.java
@@ -1,0 +1,27 @@
+package ar.com.kfgodel.temas.acciones;
+
+import ar.com.kfgodel.orm.api.TransactionContext;
+import ar.com.kfgodel.orm.api.operations.TransactionOperation;
+import com.querydsl.jpa.hibernate.HibernateQueryFactory;
+import convention.persistent.QTemaDeReunion;
+
+public class ConvertirRePropuestasAPrimerasPropuestas implements TransactionOperation {
+    private Long idDePrimeraPropuesta;
+
+    public static ConvertirRePropuestasAPrimerasPropuestas create(Long id) {
+        ConvertirRePropuestasAPrimerasPropuestas accion = new ConvertirRePropuestasAPrimerasPropuestas();
+        accion.idDePrimeraPropuesta = id;
+        return accion;
+    }
+
+    @Override
+    public Object applyWithTransactionOn(TransactionContext transactionContext) {
+        QTemaDeReunion temaDeReunion = QTemaDeReunion.temaDeReunion;
+        new HibernateQueryFactory(transactionContext.getSession())
+                .update(temaDeReunion)
+                .where(temaDeReunion.primeraPropuesta.id.eq(idDePrimeraPropuesta))
+                .setNull(temaDeReunion.primeraPropuesta)
+                .execute();
+        return null;
+    }
+}

--- a/backend/src/main/java/convention/persistent/Reunion.java
+++ b/backend/src/main/java/convention/persistent/Reunion.java
@@ -143,9 +143,9 @@ public class Reunion extends PersistableSupport {
                 });
     }
 
-    public Boolean tieneOtraRePropuestaDelMismoTema(TemaDeReunionConDescripcion unTemaDeReunion) {
+    public Boolean tieneOtroTemaQueReProponeAlMismoQue(TemaDeReunionConDescripcion unTemaDeReunion) {
         return getTemasPropuestos().stream()
-                .anyMatch(temaDeReunion -> temaDeReunion.reProponeElMismoTemaQue(unTemaDeReunion) &&
-                        !temaDeReunion.equals(unTemaDeReunion));
+                .filter(temaDeReunion -> !temaDeReunion.equals(unTemaDeReunion))
+                .anyMatch(temaDeReunion -> temaDeReunion.reProponeElMismoTemaQue(unTemaDeReunion));
     }
 }

--- a/backend/src/main/java/convention/persistent/Reunion.java
+++ b/backend/src/main/java/convention/persistent/Reunion.java
@@ -143,8 +143,9 @@ public class Reunion extends PersistableSupport {
                 });
     }
 
-    public Boolean reProponeElMismoTemaQue(TemaDeReunionConDescripcion unTemaDeReunion) {
+    public Boolean tieneOtraRePropuestaDelMismoTema(TemaDeReunionConDescripcion unTemaDeReunion) {
         return getTemasPropuestos().stream()
-                .anyMatch(temaDeReunion -> temaDeReunion.reProponeElMismoTemaQue(unTemaDeReunion));
+                .anyMatch(temaDeReunion -> temaDeReunion.reProponeElMismoTemaQue(unTemaDeReunion) &&
+                        !temaDeReunion.equals(unTemaDeReunion));
     }
 }

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -107,6 +107,7 @@ public abstract class TemaDeReunion extends Tema {
         copia.setDuracion(this.getDuracion());
         copia.setObligatoriedad(this.getObligatoriedad());
         copia.setUltimoModificador(this.getUltimoModificador());
+        copia.setPrimeraPropuesta(this.getPrimeraPropuesta());
         return copia;
     }
 

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -126,8 +126,8 @@ public class TemaDeReunionResource {
 
     private void validarTemaDeReunionConDescripcion(TemaDeReunionConDescripcion nuevoTema) {
         verificarQueNoTieneTituloDeTemaParaProponerPinosARoot(nuevoTema);
-        verificarQueNoSeReProponeUnaRePropuesta(nuevoTema);
-        verificarQueNoSeReProponeElMismoTema(nuevoTema);
+        verificarQueNoReProponeUnaRePropuesta(nuevoTema);
+        verificarQueNoHayOtroTemaEnLaReunionQueReProponeAlMismoTema(nuevoTema);
     }
 
     private void verificarQueNoTieneTituloDeTemaParaProponerPinosARoot(TemaDeReunionConDescripcion unTemaDeReunion) {
@@ -136,14 +136,14 @@ public class TemaDeReunionResource {
         }
     }
 
-    private void verificarQueNoSeReProponeUnaRePropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {
+    private void verificarQueNoReProponeUnaRePropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {
         if (unTemaDeReunion.getPrimeraPropuesta().esRePropuesta()) {
             throw new WebApplicationException("No se puede volver a proponer una re-propuesta", Response.Status.BAD_REQUEST);
         }
     }
 
-    private void verificarQueNoSeReProponeElMismoTema(TemaDeReunionConDescripcion unTemaDeReunion) {
-        if (unTemaDeReunion.getReunion().tieneOtraRePropuestaDelMismoTema(unTemaDeReunion)) {
+    private void verificarQueNoHayOtroTemaEnLaReunionQueReProponeAlMismoTema(TemaDeReunionConDescripcion unTemaDeReunion) {
+        if (unTemaDeReunion.getReunion().tieneOtroTemaQueReProponeAlMismoQue(unTemaDeReunion)) {
             throw new WebApplicationException("No se puede volver a proponer el mismo tema más de una vez", Response.Status.CONFLICT);
         }
     }

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -142,7 +142,7 @@ public class TemaDeReunionResource {
     }
 
     private void verificarQueNoSeReProponeElMismoTema(TemaDeReunionConDescripcion unTemaDeReunion) {
-        if (unTemaDeReunion.getReunion().reProponeElMismoTemaQue(unTemaDeReunion)) {
+        if (unTemaDeReunion.getReunion().tieneOtraRePropuestaDelMismoTema(unTemaDeReunion)) {
             throw new WebApplicationException("No se puede volver a proponer el mismo tema más de una vez", Response.Status.CONFLICT);
         }
     }

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -108,6 +108,7 @@ public class TemaDeReunionResource {
     @Path("/{resourceId}")
     public void delete(@PathParam("resourceId") Long id) {
         TemaDeReunion tema = temaService.get(id);
+        temaService.convertirRePropuestasAPrimerasPropuestas(id);
         temaService.delete(tema);
     }
 

--- a/backend/src/main/java/convention/services/ReunionService.java
+++ b/backend/src/main/java/convention/services/ReunionService.java
@@ -23,6 +23,9 @@ public class ReunionService extends Service<Reunion> {
   @Inject
   TemaGeneralService temaGeneralService;
 
+  @Inject
+  private TemaService temaService;
+
   public ReunionService() {
     setClasePrincipal(Reunion.class);
   }
@@ -44,6 +47,10 @@ public class ReunionService extends Service<Reunion> {
   public void delete(Long id) {
     Minuta minuta = minutaService.getFromReunion(id);
     minutaService.delete(minuta.getId());
+    Reunion reunion = get(id);
+    reunion.getTemasPropuestos().stream()
+            .filter(temaDeReunion -> !temaDeReunion.esRePropuesta())
+            .forEach(temaDeReunion -> temaService.convertirRePropuestasAPrimerasPropuestas(temaDeReunion.getId()));
     super.delete(id);
   }
 

--- a/backend/src/main/java/convention/services/TemaService.java
+++ b/backend/src/main/java/convention/services/TemaService.java
@@ -2,6 +2,7 @@ package convention.services;
 
 import ar.com.kfgodel.orm.api.operations.basic.DeleteById;
 import ar.com.kfgodel.orm.api.operations.basic.FindAll;
+import ar.com.kfgodel.temas.acciones.ConvertirRePropuestasAPrimerasPropuestas;
 import convention.persistent.StatusDeReunion;
 import convention.persistent.TemaDeReunion;
 import convention.persistent.TemaGeneral;
@@ -64,5 +65,11 @@ public class TemaService extends Service<TemaDeReunion> {
             temaModificado.actualizarTema(tema);
             this.update(tema);
         }
+    }
+
+    public void convertirRePropuestasAPrimerasPropuestas(Long id) {
+        createOperation()
+                .insideATransaction()
+                .apply(ConvertirRePropuestasAPrimerasPropuestas.create(id));
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
@@ -147,6 +147,19 @@ public class ReunionResourceTest extends ResourceTest {
         assertThat(unTemaDeReunion.getTemaGenerador().get()).isEqualTo(unTemaGeneral);
     }
 
+    @Test
+    public void testElGetDeReunionTieneLosIdsDePrimeraPropuestaCorrectos() throws IOException {
+        TemaDeReunion unaPrimeraPropuesta = temaService.save(helper.unTemaDeReunion());
+        Reunion unaReunion = reunionService.save(helper.unaReunion());
+        temaService.save(helper.unTemaDeReunionConPrimeraPropuestaParaReunion(unaPrimeraPropuesta, unaReunion));
+
+        HttpResponse response = makeGetRequest("reuniones/" + unaReunion.getId());
+
+        JSONObject jsonResponse = new JSONObject(getResponseBody(response));
+        JSONObject jsonDeLaRePropuesta = jsonResponse.getJSONArray("temasPropuestos").getJSONObject(0);
+        assertThat(jsonDeLaRePropuesta.getLong("idDePrimeraPropuesta")).isEqualTo(unaPrimeraPropuesta.getId());
+    }
+
     private Usuario unUsuarioPersistido() {
         return usuarioService.getAll().get(0);
     }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
@@ -160,6 +160,21 @@ public class ReunionResourceTest extends ResourceTest {
         assertThat(jsonDeLaRePropuesta.getLong("idDePrimeraPropuesta")).isEqualTo(unaPrimeraPropuesta.getId());
     }
 
+    @Test
+    public void testCuandoSeEliminaUnaReunionConUnaPrimeraPropuestaSusRePropuestasDejanDeSerRePropuestas() throws IOException {
+        Reunion unaReunion = reunionService.save(helper.unaReunion());
+        TemaDeReunion unaPrimeraPropuesta = temaService.save(
+                helper.unTemaDeReunion(unaReunion));
+        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunionConPrimeraPropuestaParaReunion(
+                unaPrimeraPropuesta, reunionService.save(helper.unaReunion())));
+
+        HttpResponse response = makeDeleteRequest("reuniones/" + unaReunion.getId());
+
+        assertThatResponseStatusCodeIs(response, HttpStatus.SC_NO_CONTENT);
+        assertThat(temaService.getAll()).doesNotContain(unaPrimeraPropuesta);
+        assertThat(temaService.get(unTema.getId()).esRePropuesta()).isFalse();
+    }
+
     private Usuario unUsuarioPersistido() {
         return usuarioService.getAll().get(0);
     }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -146,6 +146,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
                 helper.unTemaDeReunionConPrimeraPropuestaParaReunion(unaPrimeraPropuesta, unaReunion));
+        reunionService.save(unaReunion);
 
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(unaReunion);
         unTemaEnCreacionTo.setIdDePrimeraPropuesta(unaPrimeraPropuesta.getId());

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -1,6 +1,8 @@
 package ar.com.kfgodel.temas.apiRest;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import convention.persistent.*;
+import convention.rest.api.tos.TemaDeReunionTo;
 import convention.rest.api.tos.TemaEnCreacionTo;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -152,6 +154,23 @@ public class TemaDeReunionResourceTest extends ResourceTest {
 
         assertThatResponseStatusCodeIs(response, HttpStatus.SC_CONFLICT);
         assertThat(temaService.getAll()).containsExactly(unaPrimeraPropuesta, unTema);
+    }
+
+    @Test
+    public void testSePuedeModificarUnaRePropuesta() throws IOException {
+        TemaDeReunion unaPrimeraPropuesta = temaService.save(helper.unTemaDeReunion());
+        Reunion unaReunion = reunionService.save(helper.unaReunion());
+        TemaDeReunion unTema = temaService.save(
+                helper.unTemaDeReunionConPrimeraPropuestaParaReunion(unaPrimeraPropuesta, unaReunion));
+
+        TemaDeReunionTo toDelTema = convertirATo(unTema);
+        String unNuevoTitulo = "Un nuevo título";
+        toDelTema.setTitulo(unNuevoTitulo);
+        HttpResponse response = makeJsonPutRequest("temas/" + unTema.getId(), convertirAJsonString(toDelTema));
+
+        TemaDeReunion temaActualizado = temaService.get(unTema.getId());
+        assertThatResponseStatusCodeIs(response, HttpStatus.SC_OK);
+        assertThat(temaActualizado.getTitulo()).isEqualTo(unNuevoTitulo);
     }
 
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -172,6 +172,20 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         assertThat(temaActualizado.getTitulo()).isEqualTo(unNuevoTitulo);
     }
 
+    @Test
+    public void testCuandoSeEliminaUnaPrimeraPropuestaSusRePropuestasDejanDeSerRePropuestas() throws IOException {
+        TemaDeReunion unaPrimeraPropuesta = temaService.save(helper.unTemaDeReunion());
+        Reunion unaReunion = reunionService.save(helper.unaReunion());
+        TemaDeReunion unTema = temaService.save(
+                helper.unTemaDeReunionConPrimeraPropuestaParaReunion(unaPrimeraPropuesta, unaReunion));
+
+        HttpResponse response = makeDeleteRequest("temas/" + unaPrimeraPropuesta.getId());
+
+        assertThatResponseStatusCodeIs(response, HttpStatus.SC_NO_CONTENT);
+        assertThat(temaService.getAll()).doesNotContain(unaPrimeraPropuesta);
+        assertThat(temaService.get(unTema.getId()).esRePropuesta()).isFalse();
+    }
+
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {
         TemaDeReunionConDescripcion unTemaConDescripcion = new TemaDeReunionConDescripcion();
         temaService.save(unTemaConDescripcion);

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -1,6 +1,5 @@
 package ar.com.kfgodel.temas.apiRest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import convention.persistent.*;
 import convention.rest.api.tos.TemaDeReunionTo;
 import convention.rest.api.tos.TemaEnCreacionTo;

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -195,4 +195,10 @@ public class TestHelper {
         unTemaDeReunion.setReunion(unaReunion);
         return unTemaDeReunion;
     }
+
+    public TemaDeReunion unTemaDeReunion(Reunion unaReunion) {
+        TemaDeReunion unTemaDeReunion = unTemaDeReunion();
+        unTemaDeReunion.setReunion(unaReunion);
+        return unTemaDeReunion;
+    }
 }


### PR DESCRIPTION
Corrige los siguientes errores:
1. No se puede modificar una re-propuesta
2. El GET de reunión responde con el atributo de los temas `idDePrimeraPropuesta` incorrecto.
3. No se puede eliminar un tema que tiene re-propuestas.

Para (3) hace que las re-propuestas dejen de ser re-propuestas cuando se elimina el tema original.