### PR TITLE
Mostrar antiguedad de re propuestas

### DIFF
--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -4,6 +4,7 @@ import ar.com.kfgodel.temas.exceptions.TemaDeReunionException;
 import org.hibernate.annotations.Fetch;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -196,5 +197,13 @@ public abstract class TemaDeReunion extends Tema {
 
     public Boolean reProponeElMismoTemaQue(TemaDeReunion otroTema) {
         return Objects.equals(getPrimeraPropuesta(), otroTema.getPrimeraPropuesta());
+    }
+
+    public LocalDate getFechaDePrimeraPropuesta() {
+        return getPrimeraPropuesta().getFechaDeReunion();
+    }
+
+    private LocalDate getFechaDeReunion() {
+        return getReunion().getFecha();
     }
 }

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -25,6 +25,7 @@ public abstract class TemaDeReunion extends Tema {
     public static final String obligatoriedad_FIELD = "obligatoriedad";
     public static final String temaGenerador_FIELD = "temaGenerador";
     public static final String primeraPropuesta_FIELD = "primeraPropuesta";
+    public static final String fechaDePrimeraPropuesta_FIELD = "fechaDePrimeraPropuesta";
     public static final String ERROR_AGREGAR_INTERESADO = "No se puede agregar un interesado a un tema obligatorio";
     @ManyToOne
     private Reunion reunion;
@@ -204,6 +205,6 @@ public abstract class TemaDeReunion extends Tema {
     }
 
     private LocalDate getFechaDeReunion() {
-        return getReunion().getFecha();
+        return Optional.ofNullable(getReunion()).map(Reunion::getFecha).orElse(null);
     }
 }

--- a/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
@@ -42,6 +42,8 @@ public class TemaDeReunionTo extends PersistableToSupport {
     private String obligatoriedad;
     @CopyFrom(TemaDeReunion.primeraPropuesta_FIELD)
     private Long idDePrimeraPropuesta;
+    @CopyFrom(TemaDeReunion.fechaDePrimeraPropuesta_FIELD)
+    private String fechaDePrimeraPropuesta;
 
     public String getAutor() {
       return autor;
@@ -129,5 +131,13 @@ public class TemaDeReunionTo extends PersistableToSupport {
 
     public void setIdDePrimeraPropuesta(Long idDePrimeraPropuesta) {
         this.idDePrimeraPropuesta = idDePrimeraPropuesta;
+    }
+
+    public String getFechaDePrimeraPropuesta() {
+        return fechaDePrimeraPropuesta;
+    }
+
+    public void setFechaDePrimeraPropuesta(String fechaDePrimeraPropuesta) {
+        this.fechaDePrimeraPropuesta = fechaDePrimeraPropuesta;
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -186,6 +186,20 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         assertThat(temaService.getAll()).doesNotContain(unaPrimeraPropuesta);
         assertThat(temaService.get(unTema.getId()).esRePropuesta()).isFalse();
     }
+    
+    @Test
+    public void testGetDeTemasDeReunionContieneLaFechaDeLaPrimeraPropuesta() throws IOException {
+        Reunion unaReunion = reunionService.save(helper.unaReunion());
+        TemaDeReunion unTema = helper.unTemaDeReunion();
+        unTema.setReunion(unaReunion);
+        unTema = temaService.save(unTema);
+
+        HttpResponse response = makeGetRequest("temas/" + unTema.getId());
+
+        JSONObject jsonResponse = new JSONObject(getResponseBody(response));
+        String fechaDeLaPrimeraPropuesta = convertirA(unTema.getFechaDePrimeraPropuesta(), String.class);
+        assertThat(jsonResponse.getString("fechaDePrimeraPropuesta")).isEqualTo(fechaDeLaPrimeraPropuesta);
+    }
 
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {
         TemaDeReunionConDescripcion unTemaConDescripcion = new TemaDeReunionConDescripcion();

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -245,4 +245,13 @@ public class TemaDeReunionTest {
 
         assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isFalse();
     }
+
+    @Test
+    public void testLaFechaDeLaPrimeraPropuestaEsLaFechaDeLaReunionDeLaPrimeraPropuesta() {
+        Reunion unaReunion = helper.unaReunion();
+        TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion(unaReunion);
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
+
+        assertThat(unTema.getFechaDePrimeraPropuesta()).isEqualTo(unaReunion.getFecha());
+    }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -196,19 +196,16 @@ public class TemaDeReunionTest {
 
     @Test
     public void test20LosTemasTienenUnaPrimeraPropuesta() {
-        TemaDeReunion unTema = helper.unTemaDeReunion();
-        TemaDeReunion otroTema = helper.unTemaDeReunion();
+        TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion();
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
 
-        unTema.setPrimeraPropuesta(otroTema);
-
-        assertThat(unTema.getPrimeraPropuesta()).isEqualTo(otroTema);
+        assertThat(unTema.getPrimeraPropuesta()).isEqualTo(unaPrimeraPropuesta);
     }
 
     @Test
     public void testUnTemaEsUnaRePropuestaSiSuPrimeraPropuestaEsOtroTemaDistinto() {
-        TemaDeReunion unTema = helper.unTemaDeReunion();
-        TemaDeReunion otroTema = helper.unTemaDeReunion();
-        unTema.setPrimeraPropuesta(otroTema);
+        TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion();
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
 
         assertThat(unTema.esRePropuesta()).isTrue();
     }
@@ -224,11 +221,8 @@ public class TemaDeReunionTest {
     @Test
     public void testDosTemasReProponenElMismoTemaSiSuPrimeraPropuestaSonLaMisma() {
         TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unTemaDeReunion();
-        TemaDeReunion otroTema = helper.unTemaDeReunion();
-
-        unTema.setPrimeraPropuesta(unaPrimeraPropuesta);
-        otroTema.setPrimeraPropuesta(unaPrimeraPropuesta);
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
+        TemaDeReunion otroTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
 
         assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isTrue();
     }
@@ -237,11 +231,8 @@ public class TemaDeReunionTest {
     public void testDosTemasNoReProponenElMismoTemaSiSuPrimeraPropuestaEsDistinta() {
         TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion();
         TemaDeReunion otraPrimeraPropuesta = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unTemaDeReunion();
-        TemaDeReunion otroTema = helper.unTemaDeReunion();
-
-        unTema.setPrimeraPropuesta(unaPrimeraPropuesta);
-        otroTema.setPrimeraPropuesta(otraPrimeraPropuesta);
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
+        TemaDeReunion otroTema = helper.unaRePropuestaDe(otraPrimeraPropuesta);
 
         assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isFalse();
     }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -202,12 +202,6 @@ public class TestHelper {
         return unTemaDeReunion;
     }
 
-    public TemaDeReunion unTemaDeReunion(Reunion unaReunion) {
-        TemaDeReunion unTemaDeReunion = unTemaDeReunion();
-        unTemaDeReunion.setReunion(unaReunion);
-        return unTemaDeReunion;
-    }
-
     public TemaDeReunion unaRePropuestaDe(TemaDeReunion unaPrimeraPropuesta) {
         TemaDeReunion unTemaDeReunion = unTemaDeReunion();
         unTemaDeReunion.setPrimeraPropuesta(unaPrimeraPropuesta);

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -201,4 +201,16 @@ public class TestHelper {
         unTemaDeReunion.setReunion(unaReunion);
         return unTemaDeReunion;
     }
+
+    public TemaDeReunion unTemaDeReunion(Reunion unaReunion) {
+        TemaDeReunion unTemaDeReunion = unTemaDeReunion();
+        unTemaDeReunion.setReunion(unaReunion);
+        return unTemaDeReunion;
+    }
+
+    public TemaDeReunion unaRePropuestaDe(TemaDeReunion unaPrimeraPropuesta) {
+        TemaDeReunion unTemaDeReunion = unTemaDeReunion();
+        unTemaDeReunion.setPrimeraPropuesta(unaPrimeraPropuesta);
+        return unTemaDeReunion;
+    }
 }

--- a/frontend/app/components/header-tema.js
+++ b/frontend/app/components/header-tema.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   antiguedad: Ember.computed('tema', 'antiguedadRelativa', function(){
     if (this.get('antiguedadRelativa')){
-      return "hace" + this.tema.antiguedadDePropuesta;
+      return this.tema.get('antiguedadDePropuesta');
     } else {
       return "el " + this.tema.get('fechaDePrimeraPropuesta');
     }

--- a/frontend/app/components/header-tema.js
+++ b/frontend/app/components/header-tema.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  antiguedad: Ember.computed('tema', 'antiguedadRelativa', function(){
+    if (this.get('antiguedadRelativa')){
+      return "hace" + this.tema.antiguedadDePropuesta;
+    } else {
+      return "el " + this.tema.get('fechaDePrimeraPropuesta');
+    }
+  })
+});

--- a/frontend/app/concepts/tema.js
+++ b/frontend/app/concepts/tema.js
@@ -55,6 +55,14 @@ export default Ember.Object.extend({
     return obligatoriedad === "OBLIGATORIO" || obligatoriedad === "OBLIGATORIO_GENERAL";
   }),
 
+  esRepropuesta: Ember.computed('id', 'idDePrimeraPropuesta', function(){
+    return this.get('id') !== this.get('idDePrimeraPropuesta');
+  }),
+
+  antiguedadDePropuesta: Ember.computed('fechaDePrimeraPropuesta', function () {
+    return moment(this.get('fechaDePrimeraPropuesta')).locale('es').fromNow();
+  }),
+
   agregarInteresado(idDeInteresado) {
     this.get('idsDeInteresados').pushObject(idDeInteresado);
   },
@@ -75,6 +83,5 @@ export default Ember.Object.extend({
   }),
   esTemaParaRepasarActionItems: Ember.computed('tipo', function () {
     return this.get('tipo') === tiposDeTema.REPASAR_ACTION_ITEMS;
-  }),
-
+  })
 });

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -45,7 +45,6 @@ $ember-power-select-placeholder-color: black;
 .titulo-de-tema {
   font-size: 30px;
   font-weight: bold;
-  margin: 0;
 }
 
 .con-padding {

--- a/frontend/app/styles/utils.scss
+++ b/frontend/app/styles/utils.scss
@@ -159,6 +159,14 @@
   opacity: 0.7;
 }
 
+.text-small{
+  font-size: 0.9rem;
+}
+
+.text-gray{
+  color: darkgray;
+}
+
 .white-text {
   text-decoration: white;
 }

--- a/frontend/app/styles/utils.scss
+++ b/frontend/app/styles/utils.scss
@@ -87,6 +87,10 @@
   justify-content: space-between;
 }
 
+.align-center{
+  align-items: center;
+}
+
 .justify-center {
   justify-content: center;
 }

--- a/frontend/app/templates/components/each-card-tema.hbs
+++ b/frontend/app/templates/components/each-card-tema.hbs
@@ -1,26 +1,28 @@
 {{#if (or mostrarObligatorios (not tema.esObligatorio))}}
 
-  <tr class="bg-white">
+  <div class="p-20 bg-white mb-20">
     {{#if tema.esObligatorio}}
       <div class="the-lock lock-margin right clickable">
         <i class="material-icons opacity-20">lock</i>
         <span class="tool-tip-text">Tema obligatorio</span>
       </div>
     {{/if}}
-    <div class="tema-horizontal-margin">
-      <td class="noPadding">
-        <h5 class="titulo-de-tema">{{tema.titulo}}</h5>
-        {{descripcion-de-tema-expansible tema=tema expandido=expandido onClick=(action 'expandirDescripcion')}}
-      </td>
-
-      {{#if expandido}}
-        <div class="tema-colapse-button">
-          <button class="colapse-button" onclick={{action 'colapsarDescripcion'}}>
-            <i class="material-icons">unfold_less</i>
-          </button>
-        </div>
-      {{/if}}
+    <div class="full-width">
+      {{header-tema
+          tema=tema
+          mostrarFlagActionItems=false
+          antiguedadRelativa=true
+      }}
+      {{descripcion-de-tema-expansible tema=tema expandido=expandido onClick=(action 'expandirDescripcion')}}
     </div>
+
+    {{#if expandido}}
+      <div class="tema-colapse-button">
+        <button class="colapse-button" onclick={{action 'colapsarDescripcion'}}>
+          <i class="material-icons">unfold_less</i>
+        </button>
+      </div>
+    {{/if}}
 
     <div class="divider"></div>
 
@@ -84,6 +86,6 @@
 
       </div>
     </div>
-  </tr>
+  </div>
 
 {{/if}}

--- a/frontend/app/templates/components/header-tema.hbs
+++ b/frontend/app/templates/components/header-tema.hbs
@@ -1,0 +1,9 @@
+<div class="space-between align-center">
+  <h5 class="titulo-de-tema no-margin">{{tema.titulo}} </h5>
+  {{#if tema.esRepropuesta}}
+    <h6 class="no-margin">Propuesto originalmente {{antiguedad}}</h6>
+  {{/if}}
+  {{#if mostrarFlagActionItems}}
+    <i class="material-icons primary-color">flag</i>
+  {{/if}}
+</div>

--- a/frontend/app/templates/components/header-tema.hbs
+++ b/frontend/app/templates/components/header-tema.hbs
@@ -1,7 +1,7 @@
 <div class="space-between align-center">
   <h5 class="titulo-de-tema no-margin">{{tema.titulo}} </h5>
   {{#if tema.esRepropuesta}}
-    <h6 class="no-margin">Propuesto originalmente {{antiguedad}}</h6>
+    <h6 class="no-margin text-gray text-small">Propuesto originalmente {{antiguedad}}</h6>
   {{/if}}
   {{#if mostrarFlagActionItems}}
     <i class="material-icons primary-color">flag</i>

--- a/frontend/app/templates/components/tema-de-minuta.hbs
+++ b/frontend/app/templates/components/tema-de-minuta.hbs
@@ -1,11 +1,10 @@
 <div class="flex space-between p-20" {{action 'verDetalleDeTema'}}>
   <div class="flex-1">
-    <div class="noPadding flex space-between">
-      <h5 class="titulo-de-tema">{{temaDeMinuta.tema.titulo}} </h5>
-      {{#if mostrarFlagActionItems}}
-        <i class="material-icons primary-color">flag</i>
-      {{/if}}
-    </div>
+    {{header-tema
+        tema=temaConComportamiento
+        mostrarFlagActionItems=mostrarFlagActionItems
+        antiguedadRelativa=false
+    }}
     {{#if mostrarDescripcion}}
       {{descripcion-de-tema-expansible tema=temaConComportamiento expandido=textoExtendido
                          onClick=(action 'expandirDescripcion')}}

--- a/frontend/tests/integration/components/header-tema-test.js
+++ b/frontend/tests/integration/components/header-tema-test.js
@@ -1,0 +1,30 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describeComponent,
+  it
+} from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent(
+  'header-tema',
+  'Integration: HeaderTemaComponent',
+  {
+    integration: true
+  },
+  function() {
+    it('renders', function() {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.on('myAction', function(val) { ... });
+      // Template block usage:
+      // this.render(hbs`
+      //   {{#header-tema}}
+      //     template content
+      //   {{/header-tema}}
+      // `);
+
+      this.render(hbs`{{header-tema}}`);
+      expect(this.$()).to.have.length(1);
+    });
+  }
+);


### PR DESCRIPTION
Muestra la antiguedad de la primera propuesta de un tema. En reunion de forma relativa y "fuzzy" (Propuesto originalmente hace un mes) y de forma absoluta en la minuta (Propuesto originalmente el 2019-08-01).

[Historia de trello: Si el tema fue re-propuesto, mostrar la antiguedad del mismo](https://trello.com/c/9kHzHMJ0/152-si-el-tema-fue-re-propuesto-mostrar-la-antiguedad-del-mismo)

### Tema de reunion
![Screenshot from 2019-08-30 11-30-54](https://user-images.githubusercontent.com/17646954/64029091-46449a00-cb1a-11e9-8c4b-a5feafa1e940.png)

### Tema de minuta
![Screenshot from 2019-08-30 11-33-10](https://user-images.githubusercontent.com/17646954/64029094-46dd3080-cb1a-11e9-80ab-74762d8e646b.png)
