### PR TITLE
Fix: el tema para proponer pinos como root no tiene autor

### DIFF
--- a/backend/src/main/java/convention/persistent/Reunion.java
+++ b/backend/src/main/java/convention/persistent/Reunion.java
@@ -117,18 +117,19 @@ public class Reunion extends PersistableSupport {
 
     public void proponerPinoComoRoot(String unPino, Usuario unSponsor) {
         PropuestaDePinoARoot propuesta = new PropuestaDePinoARoot(unPino, unSponsor);
-        getTemaParaProponerPinosARoot().agregarPropuesta(propuesta);
+        getTemaParaProponerPinosARootPara(unSponsor).agregarPropuesta(propuesta);
     }
 
-    private TemaParaProponerPinosARoot getTemaParaProponerPinosARoot() {
+    private TemaParaProponerPinosARoot getTemaParaProponerPinosARootPara(Usuario unSponsor) {
         return (TemaParaProponerPinosARoot) getTemasPropuestos().stream()
                 .filter(TemaDeReunion::esParaProponerPinosARoot).findFirst()
-                .orElseGet(this::crearTemaParaProponerPinosARoot);
+                .orElseGet(() -> crearTemaParaProponerPinosARootPara(unSponsor));
     }
 
-    private TemaParaProponerPinosARoot crearTemaParaProponerPinosARoot() {
+    private TemaParaProponerPinosARoot crearTemaParaProponerPinosARootPara(Usuario unAutor) {
         TemaParaProponerPinosARoot temaParaProponerPinos = new TemaParaProponerPinosARoot();
         temaParaProponerPinos.setReunion(this);
+        temaParaProponerPinos.setAutor(unAutor);
         temasPropuestos.add(temaParaProponerPinos);
         return temaParaProponerPinos;
     }

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/ReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/ReunionTest.java
@@ -229,6 +229,18 @@ public class ReunionTest {
         }).hasMessage(Reunion.AGREGAR_TEMA_PARA_PROPONER_PINOS_COMO_ROOT_ERROR_MSG);
     }
 
+    @Test
+    public void testElAutorDelTemaParaProponerPinosComoRootsEsElPrimerUsuarioQueHizoUnaPropuesta() {
+        Reunion unaReunion = helper.unaReunion();
+
+        String unPino = helper.unPino();
+        Usuario unSponsor = helper.unUsuario();
+        unaReunion.proponerPinoComoRoot(unPino, unSponsor);
+
+        TemaDeReunion temaCreado = unaReunion.getTemasPropuestos().get(0);
+        assertThat(temaCreado.getAutor()).isEqualTo(unSponsor);
+    }
+
     private void assertThatExistePropuestaPara(Collection<PropuestaDePinoARoot> propuestas, String unPino, Usuario unSponsor) {
         assertThat(propuestas).anyMatch(
                 propuesta -> propuesta.pino().equals(unPino) && propuesta.sponsor() == unSponsor);


### PR DESCRIPTION
Hace que el primer usuario que propone a un pino como root quede como el autor del tema.