### PR TITLE
Hace que solo las re-propuestas tengan una propuesta original

### DIFF
--- a/backend/src/main/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratados.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratados.java
@@ -106,7 +106,7 @@ public class NotificadorDeTemasNoTratados {
     }
 
     private String getLinkParaReProponer(TemaDeReunion unTemaDeReunion) {
-        return String.format("%s/reproponer-tema/%d", getHostName(), unTemaDeReunion.getPropuestaOriginal().getId());
+        return String.format("%s/reproponer-tema/%d", getHostName(), unTemaDeReunion.propuestaTratada().getId());
     }
 
     private String getHostName() {

--- a/backend/src/main/java/convention/persistent/Reunion.java
+++ b/backend/src/main/java/convention/persistent/Reunion.java
@@ -144,9 +144,9 @@ public class Reunion extends PersistableSupport {
                 });
     }
 
-    public Boolean tieneOtroTemaQueReProponeAlMismoQue(TemaDeReunionConDescripcion unTemaDeReunion) {
+    public Boolean tieneOtroTemaQueTrataLaMismaPropuestaQue(TemaDeReunionConDescripcion unTemaDeReunion) {
         return getTemasPropuestos().stream()
                 .filter(temaDeReunion -> !temaDeReunion.equals(unTemaDeReunion))
-                .anyMatch(temaDeReunion -> temaDeReunion.reProponeElMismoTemaQue(unTemaDeReunion));
+                .anyMatch(temaDeReunion -> temaDeReunion.trataLaMismaPropuestaQue(unTemaDeReunion));
     }
 }

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -204,10 +204,6 @@ public abstract class TemaDeReunion extends Tema {
         return !Objects.isNull(propuestaOriginal);
     }
 
-    public Boolean reProponeElMismoTemaQue(TemaDeReunion otroTema) {
-        return Objects.equals(getPropuestaOriginal(), otroTema.getPropuestaOriginal());
-    }
-
     public TemaDeReunion propuestaTratada() {
         return Optional.ofNullable(getPropuestaOriginal()).orElse(this);
     }

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -25,8 +25,9 @@ public abstract class TemaDeReunion extends Tema {
     public static final String obligatoriedad_FIELD = "obligatoriedad";
     public static final String temaGenerador_FIELD = "temaGenerador";
     public static final String propuestaOriginal_FIELD = "propuestaOriginal";
-    public static final String fechaDePrimeraPropuesta_FIELD = "fechaDePrimeraPropuesta";
+    public static final String fechaDePropuestaOriginal_FIELD = "fechaDePropuestaOriginal";
     public static final String ERROR_AGREGAR_INTERESADO = "No se puede agregar un interesado a un tema obligatorio";
+    public static final String ERROR_PROPIA_PROPUESTA_ORIGINAL = "Un tema no puede ser su propia propuesta original";
     @ManyToOne
     private Reunion reunion;
     private Integer prioridad;
@@ -185,23 +186,38 @@ public abstract class TemaDeReunion extends Tema {
     }
 
     public void setPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
+        verificarQueNoEsSuPropiaPropuestaOriginal(unTemaDeReunion);
         propuestaOriginal = unTemaDeReunion;
     }
 
+    private void verificarQueNoEsSuPropiaPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
+        if (equals(unTemaDeReunion)) {
+            throw new RuntimeException(ERROR_PROPIA_PROPUESTA_ORIGINAL);
+        }
+    }
+
     public TemaDeReunion getPropuestaOriginal() {
-        return Optional.ofNullable(propuestaOriginal).orElse(this);
+        return propuestaOriginal;
     }
 
     public Boolean esRePropuesta() {
-        return !Objects.equals(getPropuestaOriginal(), this);
+        return !Objects.isNull(propuestaOriginal);
     }
 
     public Boolean reProponeElMismoTemaQue(TemaDeReunion otroTema) {
         return Objects.equals(getPropuestaOriginal(), otroTema.getPropuestaOriginal());
     }
 
-    public LocalDate getFechaDePrimeraPropuesta() {
-        return getPropuestaOriginal().getFechaDeReunion();
+    public TemaDeReunion propuestaTratada() {
+        return Optional.ofNullable(getPropuestaOriginal()).orElse(this);
+    }
+
+    public Boolean trataLaMismaPropuestaQue(TemaDeReunion unTemaDeReunion) {
+        return propuestaTratada().equals(unTemaDeReunion.propuestaTratada());
+    }
+
+    public LocalDate getFechaDePropuestaOriginal() {
+        return Optional.ofNullable(propuestaOriginal).map(TemaDeReunion::getFechaDeReunion).orElse(null);
     }
 
     private LocalDate getFechaDeReunion() {

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -185,19 +185,14 @@ public abstract class TemaDeReunion extends Tema {
         return false;
     }
 
-    public void setPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
-        verificarQueNoEsSuPropiaPropuestaOriginal(unTemaDeReunion);
-        propuestaOriginal = unTemaDeReunion;
-    }
-
     private void verificarQueNoEsSuPropiaPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
         if (equals(unTemaDeReunion)) {
             throw new RuntimeException(ERROR_PROPIA_PROPUESTA_ORIGINAL);
         }
     }
 
-    public TemaDeReunion getPropuestaOriginal() {
-        return propuestaOriginal;
+    public Optional<TemaDeReunion> propuestaOriginal() {
+        return Optional.ofNullable(propuestaOriginal);
     }
 
     public Boolean esRePropuesta() {
@@ -205,7 +200,7 @@ public abstract class TemaDeReunion extends Tema {
     }
 
     public TemaDeReunion propuestaTratada() {
-        return Optional.ofNullable(getPropuestaOriginal()).orElse(this);
+        return propuestaOriginal().orElse(this);
     }
 
     public Boolean trataLaMismaPropuestaQue(TemaDeReunion unTemaDeReunion) {
@@ -218,5 +213,14 @@ public abstract class TemaDeReunion extends Tema {
 
     private LocalDate getFechaDeReunion() {
         return Optional.ofNullable(getReunion()).map(Reunion::getFecha).orElse(null);
+    }
+
+    public TemaDeReunion getPropuestaOriginal() {
+        return propuestaOriginal;
+    }
+
+    public void setPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
+        verificarQueNoEsSuPropiaPropuestaOriginal(unTemaDeReunion);
+        propuestaOriginal = unTemaDeReunion;
     }
 }

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -137,9 +137,11 @@ public class TemaDeReunionResource {
     }
 
     private void verificarQueNoReProponeUnaRePropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {
-        if (unTemaDeReunion.getPropuestaOriginal().esRePropuesta()) {
-            throw new WebApplicationException("No se puede volver a proponer una re-propuesta", Response.Status.BAD_REQUEST);
-        }
+        unTemaDeReunion.propuestaOriginal().ifPresent(propuestaOriginal -> {
+            if (propuestaOriginal.esRePropuesta()) {
+                throw new WebApplicationException("No se puede volver a proponer una re-propuesta", Response.Status.BAD_REQUEST);
+            }
+        });
     }
 
     private void verificarQueNoHayOtroTemaEnLaReunionQueTrataLaMismaPropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -127,7 +127,7 @@ public class TemaDeReunionResource {
     private void validarTemaDeReunionConDescripcion(TemaDeReunionConDescripcion nuevoTema) {
         verificarQueNoTieneTituloDeTemaParaProponerPinosARoot(nuevoTema);
         verificarQueNoReProponeUnaRePropuesta(nuevoTema);
-        verificarQueNoHayOtroTemaEnLaReunionQueReProponeAlMismoTema(nuevoTema);
+        verificarQueNoHayOtroTemaEnLaReunionQueTrataLaMismaPropuesta(nuevoTema);
     }
 
     private void verificarQueNoTieneTituloDeTemaParaProponerPinosARoot(TemaDeReunionConDescripcion unTemaDeReunion) {
@@ -142,8 +142,8 @@ public class TemaDeReunionResource {
         }
     }
 
-    private void verificarQueNoHayOtroTemaEnLaReunionQueReProponeAlMismoTema(TemaDeReunionConDescripcion unTemaDeReunion) {
-        if (unTemaDeReunion.getReunion().tieneOtroTemaQueReProponeAlMismoQue(unTemaDeReunion)) {
+    private void verificarQueNoHayOtroTemaEnLaReunionQueTrataLaMismaPropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {
+        if (unTemaDeReunion.getReunion().tieneOtroTemaQueTrataLaMismaPropuestaQue(unTemaDeReunion)) {
             throw new WebApplicationException("No se puede volver a proponer el mismo tema más de una vez", Response.Status.CONFLICT);
         }
     }

--- a/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
@@ -42,8 +42,8 @@ public class TemaDeReunionTo extends PersistableToSupport {
     private String obligatoriedad;
     @CopyFrom(TemaDeReunion.propuestaOriginal_FIELD)
     private Long idDePropuestaOriginal;
-    @CopyFrom(TemaDeReunion.fechaDePrimeraPropuesta_FIELD)
-    private String fechaDePrimeraPropuesta;
+    @CopyFrom(TemaDeReunion.fechaDePropuestaOriginal_FIELD)
+    private String fechaDePropuestaOriginal;
 
     public String getAutor() {
       return autor;
@@ -133,11 +133,11 @@ public class TemaDeReunionTo extends PersistableToSupport {
         this.idDePropuestaOriginal = idDePropuestaOriginal;
     }
 
-    public String getFechaDePrimeraPropuesta() {
-        return fechaDePrimeraPropuesta;
+    public String getFechaDePropuestaOriginal() {
+        return fechaDePropuestaOriginal;
     }
 
-    public void setFechaDePrimeraPropuesta(String fechaDePrimeraPropuesta) {
-        this.fechaDePrimeraPropuesta = fechaDePrimeraPropuesta;
+    public void setFechaDePropuestaOriginal(String fechaDePropuestaOriginal) {
+        this.fechaDePropuestaOriginal = fechaDePropuestaOriginal;
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
@@ -150,7 +150,7 @@ public class ReunionResourceTest extends ResourceTest {
     public void testElGetDeReunionTieneLosIdsDePropuestaOriginalCorrectos() throws IOException {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
-        temaService.save(helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
+        temaService.save(helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
 
         HttpResponse response = makeGetRequest("reuniones/" + unaReunion.getId());
 
@@ -164,7 +164,7 @@ public class ReunionResourceTest extends ResourceTest {
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unaPropuestaOriginal = temaService.save(
                 helper.unTemaDeReunion(unaReunion));
-        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunionConPropuestaOriginalParaReunion(
+        TemaDeReunion unTema = temaService.save(helper.unaRePropuestaDeParaReunion(
                 unaPropuestaOriginal, reunionService.save(helper.unaReunion())));
 
         HttpResponse response = makeDeleteRequest("reuniones/" + unaReunion.getId());

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -99,7 +99,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
 
         Long idDelTemaCreado = new JSONObject(getResponseBody(response)).getLong("id");
         TemaDeReunion temaCreado = temaService.get(idDelTemaCreado);
-        assertThat(temaCreado.getPropuestaOriginal()).isEqualTo(unaPropuestaOriginal);
+        assertThat(temaCreado.propuestaOriginal().get()).isEqualTo(unaPropuestaOriginal);
     }
 
     @Test

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -176,17 +176,16 @@ public class TemaDeReunionResourceTest extends ResourceTest {
     }
     
     @Test
-    public void testGetDeTemasDeReunionContieneLaFechaDeLaPrimeraPropuesta() throws IOException {
+    public void testGetDeTemasDeReunionContieneLaFechaDeLaPropuestaOriginal() throws IOException {
         Reunion unaReunion = reunionService.save(helper.unaReunion());
-        TemaDeReunion unTema = helper.unTemaDeReunion();
-        unTema.setReunion(unaReunion);
-        unTema = temaService.save(unTema);
+        TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion(unaReunion));
+        TemaDeReunion unTema = temaService.save(helper.unaRePropuestaDe(unaPropuestaOriginal));
 
         HttpResponse response = makeGetRequest("temas/" + unTema.getId());
 
         JSONObject jsonResponse = new JSONObject(getResponseBody(response));
-        String fechaDeLaPrimeraPropuesta = convertirA(unTema.getFechaDePropuestaOriginal(), String.class);
-        assertThat(jsonResponse.getString("fechaDePropuestaOriginal")).isEqualTo(fechaDeLaPrimeraPropuesta);
+        String fechaDeLaPropuestaOriginal = convertirA(unTema.getFechaDePropuestaOriginal(), String.class);
+        assertThat(jsonResponse.getString("fechaDePropuestaOriginal")).isEqualTo(fechaDeLaPropuestaOriginal);
     }
 
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -90,38 +90,28 @@ public class TemaDeReunionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testUnTemaSeCreaConUnaPropuestaOriginal() throws IOException {
-        TemaDeReunionConDescripcion unTemaDeReunion = crearUnTemaDeReunionConDescripcion();
+    public void testUnaRePropuestaSeCreaCreandoUnTemaConUnaPropuestaOriginal() throws IOException {
+        TemaDeReunionConDescripcion unaPropuestaOriginal = crearUnTemaDeReunionConDescripcion();
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
-        unTemaEnCreacionTo.setIdDePropuestaOriginal(unTemaDeReunion.getId());
+        unTemaEnCreacionTo.setIdDePropuestaOriginal(unaPropuestaOriginal.getId());
 
         HttpResponse response = makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
 
         Long idDelTemaCreado = new JSONObject(getResponseBody(response)).getLong("id");
         TemaDeReunion temaCreado = temaService.get(idDelTemaCreado);
-        assertThat(temaCreado.getPropuestaOriginal()).isEqualTo(unTemaDeReunion);
+        assertThat(temaCreado.getPropuestaOriginal()).isEqualTo(unaPropuestaOriginal);
     }
 
     @Test
     public void testGetDeUnaRePropuestaContieneElIdDeLaPropuestaOriginal() throws IOException {
+        TemaDeReunionConDescripcion unaPropuestaOriginal = crearUnTemaDeReunionConDescripcion();
         Reunion unaReunion = reunionService.save(helper.unaReunion());
-        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunion(unaReunion));
+        TemaDeReunion unTema = temaService.save(helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
 
         HttpResponse response = makeGetRequest("temas/" + unTema.getId());
 
         JSONObject jsonResponse = new JSONObject(getResponseBody(response));
-        assertThat(jsonResponse.getLong("idDePropuestaOriginal")).isEqualTo(unTema.getPropuestaOriginal().getId());
-    }
-
-    @Test
-    public void testUnTemaSeCreaConsigoMismoComoPropuestaOriginalSiNoSeEspecificaUna() throws IOException {
-        TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
-        unTemaEnCreacionTo.setIdDePropuestaOriginal(null);
-
-        makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
-
-        TemaDeReunion temaCreado = temaService.getAll().get(0);
-        assertThat(temaCreado.getPropuestaOriginal()).isEqualTo(temaCreado);
+        assertThat(jsonResponse.getLong("idDePropuestaOriginal")).isEqualTo(unaPropuestaOriginal.getId());
     }
 
     @Test
@@ -143,7 +133,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
+                helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
         reunionService.save(unaReunion);
 
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(unaReunion);
@@ -159,7 +149,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
+                helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
 
         TemaDeReunionTo toDelTema = convertirATo(unTema);
         String unNuevoTitulo = "Un nuevo título";
@@ -176,7 +166,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
+                helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
 
         HttpResponse response = makeDeleteRequest("temas/" + unaPropuestaOriginal.getId());
 

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -103,6 +103,17 @@ public class TemaDeReunionResourceTest extends ResourceTest {
     }
 
     @Test
+    public void testGetDeUnaRePropuestaContieneElIdDeLaPropuestaOriginal() throws IOException {
+        Reunion unaReunion = reunionService.save(helper.unaReunion());
+        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunion(unaReunion));
+
+        HttpResponse response = makeGetRequest("temas/" + unTema.getId());
+
+        JSONObject jsonResponse = new JSONObject(getResponseBody(response));
+        assertThat(jsonResponse.getLong("idDePropuestaOriginal")).isEqualTo(unTema.getPropuestaOriginal().getId());
+    }
+
+    @Test
     public void testUnTemaSeCreaConsigoMismoComoPropuestaOriginalSiNoSeEspecificaUna() throws IOException {
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
         unTemaEnCreacionTo.setIdDePropuestaOriginal(null);
@@ -114,20 +125,9 @@ public class TemaDeReunionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testGetDeTemasDeReunionContieneElIdDeLaPropuestaOriginal() throws IOException {
-        Reunion unaReunion = reunionService.save(helper.unaReunion());
-        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunion(unaReunion));
-
-        HttpResponse response = makeGetRequest("temas/" + unTema.getId());
-
-        JSONObject jsonResponse = new JSONObject(getResponseBody(response));
-        assertThat(jsonResponse.getLong("idDePropuestaOriginal")).isEqualTo(unTema.getPropuestaOriginal().getId());
-    }
-
-    @Test
     public void testCrearUnTemaConUnaRePropuestaComoPropuestaOriginalRetornaUnBadRequest() throws IOException {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
-        TemaDeReunion unaRePropuesta = temaService.save(helper.unTemaDeReunionConPropuestaOriginal(unaPropuestaOriginal));
+        TemaDeReunion unaRePropuesta = temaService.save(helper.unaRePropuestaDe(unaPropuestaOriginal));
 
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
         unTemaEnCreacionTo.setIdDePropuestaOriginal(unaRePropuesta.getId());
@@ -195,8 +195,8 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         HttpResponse response = makeGetRequest("temas/" + unTema.getId());
 
         JSONObject jsonResponse = new JSONObject(getResponseBody(response));
-        String fechaDeLaPrimeraPropuesta = convertirA(unTema.getFechaDePrimeraPropuesta(), String.class);
-        assertThat(jsonResponse.getString("fechaDePrimeraPropuesta")).isEqualTo(fechaDeLaPrimeraPropuesta);
+        String fechaDeLaPrimeraPropuesta = convertirA(unTema.getFechaDePropuestaOriginal(), String.class);
+        assertThat(jsonResponse.getString("fechaDePropuestaOriginal")).isEqualTo(fechaDeLaPrimeraPropuesta);
     }
 
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 
 import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.Is.is;
 
 /**
@@ -205,36 +206,48 @@ public class TemaDeReunionTest {
     @Test
     public void testUnTemaEsUnaRePropuestaSiSuPropuestaOriginalEsOtroTemaDistinto() {
         TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
+        TemaDeReunion unaRepropuesta = helper.unaRePropuestaDe(unaPropuestaOriginal);
 
-        assertThat(unTema.esRePropuesta()).isTrue();
+        assertThat(unaRepropuesta.esRePropuesta()).isTrue();
     }
 
     @Test
-    public void testUnTemaNoEsRePropuestaSiSuPropuestaOriginalEsElMismo() {
+    public void testUnTemaNoEsRePropuestaSiSuPropuestaOriginalNoEsOtroTemaDistinto() {
         TemaDeReunion unTema = helper.unTemaDeReunion();
-        unTema.setPropuestaOriginal(unTema);
+        unTema.setPropuestaOriginal(null);
 
         assertThat(unTema.esRePropuesta()).isFalse();
     }
 
     @Test
-    public void testDosTemasReProponenElMismoTemaSiSuPropuestaOriginalSonLaMisma() {
-        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
-        TemaDeReunion otroTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
+    public void testLaPropuestaOriginalDeUnTemaNoPuedeSerElMismo() {
+        TemaDeReunion unTema = helper.unTemaDeReunion();
 
-        assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isTrue();
+        assertThatThrownBy(() -> {
+            unTema.setPropuestaOriginal(unTema);
+        }).hasMessage(TemaDeReunion.ERROR_PROPIA_PROPUESTA_ORIGINAL);
     }
 
     @Test
-    public void testDosTemasNoReProponenElMismoTemaSiSuPropuestaOriginalEsDistinta() {
-        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
-        TemaDeReunion otraPropuestaOriginal = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
-        TemaDeReunion otroTema = helper.unaRePropuestaDe(otraPropuestaOriginal);
+    public void testLaPropuestaTratadaDeUnaRePropuestaEsSuPropuestaOriginal() {
+        TemaDeReunion unaRePropuesta = helper.unaRePropuesta();
 
-        assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isFalse();
+        assertThat(unaRePropuesta.propuestaTratada()).isEqualTo(unaRePropuesta.getPropuestaOriginal());
+    }
+
+    @Test
+    public void testLaPropuestaTratadaDeUnTemaOriginalEsElMismo() {
+        TemaDeReunion unTemaOriginal = helper.unTemaDeReunion();
+
+        assertThat(unTemaOriginal.propuestaTratada()).isEqualTo(unTemaOriginal);
+    }
+
+    @Test
+    public void testDosTemasTratanLaMismaPropuestaSiSuPropuestaTratadaEsLaMisma() {
+        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
+
+        assertThat(unaPropuestaOriginal.trataLaMismaPropuestaQue(unTema)).isTrue();
     }
 
     @Test
@@ -243,6 +256,6 @@ public class TemaDeReunionTest {
         TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion(unaReunion);
         TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
 
-        assertThat(unTema.getFechaDePrimeraPropuesta()).isEqualTo(unaReunion.getFecha());
+        assertThat(unTema.getFechaDePropuestaOriginal()).isEqualTo(unaReunion.getFecha());
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -200,7 +200,7 @@ public class TemaDeReunionTest {
         TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
         TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
 
-        assertThat(unTema.getPropuestaOriginal()).isEqualTo(unaPropuestaOriginal);
+        assertThat(unTema.propuestaOriginal().get()).isEqualTo(unaPropuestaOriginal);
     }
 
     @Test
@@ -232,7 +232,7 @@ public class TemaDeReunionTest {
     public void testLaPropuestaTratadaDeUnaRePropuestaEsSuPropuestaOriginal() {
         TemaDeReunion unaRePropuesta = helper.unaRePropuesta();
 
-        assertThat(unaRePropuesta.propuestaTratada()).isEqualTo(unaRePropuesta.getPropuestaOriginal());
+        assertThat(unaRePropuesta.propuestaTratada()).isEqualTo(unaRePropuesta.propuestaOriginal().get());
     }
 
     @Test

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -240,7 +240,7 @@ public class TestHelper {
         return unTemaDeReunion;
     }
 
-    public TemaDeReunion unTemaDeReunionConPropuestaOriginalParaReunion(TemaDeReunion unaPropuestaOriginal, Reunion unaReunion) {
+    public TemaDeReunion unaRePropuestaDeParaReunion(TemaDeReunion unaPropuestaOriginal, Reunion unaReunion) {
         TemaDeReunion unTemaDeReunion = unaRePropuestaDe(unaPropuestaOriginal);
         unTemaDeReunion.setReunion(unaReunion);
         return unTemaDeReunion;

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -229,14 +229,19 @@ public class TestHelper {
         return typeTransformer.transformTo(unaClaseDestino, unObjeto);
     }
 
-    public TemaDeReunion unTemaDeReunionConPropuestaOriginal(TemaDeReunion unaPropuestaOriginal) {
+    public TemaDeReunion unaRePropuesta() {
+        TemaDeReunion unaPropuestaOriginal = unTemaDeReunion();
+        return unaRePropuestaDe(unaPropuestaOriginal);
+    }
+
+    public TemaDeReunion unaRePropuestaDe(TemaDeReunion unaPropuestaOriginal) {
         TemaDeReunion unTemaDeReunion = unTemaDeReunion();
         unTemaDeReunion.setPropuestaOriginal(unaPropuestaOriginal);
         return unTemaDeReunion;
     }
 
     public TemaDeReunion unTemaDeReunionConPropuestaOriginalParaReunion(TemaDeReunion unaPropuestaOriginal, Reunion unaReunion) {
-        TemaDeReunion unTemaDeReunion = unTemaDeReunionConPropuestaOriginal(unaPropuestaOriginal);
+        TemaDeReunion unTemaDeReunion = unaRePropuestaDe(unaPropuestaOriginal);
         unTemaDeReunion.setReunion(unaReunion);
         return unTemaDeReunion;
     }
@@ -244,12 +249,6 @@ public class TestHelper {
     public TemaDeReunion unTemaDeReunion(Reunion unaReunion) {
         TemaDeReunion unTemaDeReunion = unTemaDeReunion();
         unTemaDeReunion.setReunion(unaReunion);
-        return unTemaDeReunion;
-    }
-
-    public TemaDeReunion unaRePropuestaDe(TemaDeReunion unaPrimeraPropuesta) {
-        TemaDeReunion unTemaDeReunion = unTemaDeReunion();
-        unTemaDeReunion.setPropuestaOriginal(unaPrimeraPropuesta);
         return unTemaDeReunion;
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratadosTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratadosTest.java
@@ -94,7 +94,7 @@ public class NotificadorDeTemasNoTratadosTest {
         assertThat(remitente.getName()).isEqualTo("Aviso Tema No Propuesto");
         assertThat(remitente.getAddress()).isEqualTo(MailerConfiguration.getSenderAdress());
         assertThat(emailEnviado.getSubject()).isEqualTo(String.format("Tu tema \"%s\" no fue tratado", tituloDelTema));
-        String linkParaReproponerTema = String.format("%s/reproponer-tema/%d", getHostName(), temaNoTratado.getPropuestaOriginal().getId());
+        String linkParaReproponerTema = String.format("%s/reproponer-tema/%d", getHostName(), temaNoTratado.propuestaTratada().getId());
         assertThat(emailEnviado.getPlainText()).isEqualTo(
                 String.format("Hola! El tema \"%s\" que presentaste en la roots pasada no fue tratado. " +
                                 "Sentite libre de volver a proponerlo con este link %s",

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -226,7 +226,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
             this.set('nuevoTema', Tema.create({
               idDeReunion: this._idDeReunion(),
               idDeAutor: this._idDeUsuarioActual(),
-              idDePropuestaOriginal: tema.idDePropuestaOriginal,
+              idDePropuestaOriginal: tema.esRepropuesta ? tema.idDePropuestaOriginal : tema.id,
               duracion: tema.duracion,
               titulo: tema.titulo,
               descripcion: tema.descripcion,


### PR DESCRIPTION
El objetivo de este PR es hacer que en la API las propuestas originales (temas que no son re-propuesta de otro) dejen de tener un campo `idDePropuestaOriginal` que referencien a ellas mismas porque es confuso. Lo que se decidió que era mejor es que sea `null` para propuestas originales.


---

Los temas tienen un método `getPropuestaOriginal()` que devuelve la propuesta original del tema si es una re-propuesta o al mismo tema si es una propuesta original. Este PR hace que ya no devuelva al mismo tema en el último caso. `getPropuestaOriginal()` pasa a devolver null, pero este método sólo está para que sea usado por el TypeConverter. El que se debería usar es `propuestaOriginal()` que devuelve un `Optional`.

Por otro lado, se agrega un nuevo método `propuestaTratada()` que tiene el comportamiento que tiene `getPropuestaOriginal()` ahora (devolver la propuesta original o el mismo tema). Se usa en algunos casos en los que se usaba `getPropuestaOriginal()`. Por ejemplo, para generar el link para re-proponer.