### PR TITLE
Refactoriza re propuestas de temas

### DIFF
--- a/backend/src/main/java/ar/com/kfgodel/temas/acciones/ConvertirRePropuestasAPropuestasOriginales.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/acciones/ConvertirRePropuestasAPropuestasOriginales.java
@@ -5,12 +5,12 @@ import ar.com.kfgodel.orm.api.operations.TransactionOperation;
 import com.querydsl.jpa.hibernate.HibernateQueryFactory;
 import convention.persistent.QTemaDeReunion;
 
-public class ConvertirRePropuestasAPrimerasPropuestas implements TransactionOperation {
-    private Long idDePrimeraPropuesta;
+public class ConvertirRePropuestasAPropuestasOriginales implements TransactionOperation {
+    private Long idDePropuestaOriginal;
 
-    public static ConvertirRePropuestasAPrimerasPropuestas create(Long id) {
-        ConvertirRePropuestasAPrimerasPropuestas accion = new ConvertirRePropuestasAPrimerasPropuestas();
-        accion.idDePrimeraPropuesta = id;
+    public static ConvertirRePropuestasAPropuestasOriginales create(Long id) {
+        ConvertirRePropuestasAPropuestasOriginales accion = new ConvertirRePropuestasAPropuestasOriginales();
+        accion.idDePropuestaOriginal = id;
         return accion;
     }
 
@@ -19,8 +19,8 @@ public class ConvertirRePropuestasAPrimerasPropuestas implements TransactionOper
         QTemaDeReunion temaDeReunion = QTemaDeReunion.temaDeReunion;
         new HibernateQueryFactory(transactionContext.getSession())
                 .update(temaDeReunion)
-                .where(temaDeReunion.primeraPropuesta.id.eq(idDePrimeraPropuesta))
-                .setNull(temaDeReunion.primeraPropuesta)
+                .where(temaDeReunion.propuestaOriginal.id.eq(idDePropuestaOriginal))
+                .setNull(temaDeReunion.propuestaOriginal)
                 .execute();
         return null;
     }

--- a/backend/src/main/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratados.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratados.java
@@ -106,7 +106,7 @@ public class NotificadorDeTemasNoTratados {
     }
 
     private String getLinkParaReProponer(TemaDeReunion unTemaDeReunion) {
-        return String.format("%s/reproponer-tema/%d", getHostName(), unTemaDeReunion.getPrimeraPropuesta().getId());
+        return String.format("%s/reproponer-tema/%d", getHostName(), unTemaDeReunion.getPropuestaOriginal().getId());
     }
 
     private String getHostName() {

--- a/backend/src/main/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratados.java
+++ b/backend/src/main/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratados.java
@@ -106,7 +106,7 @@ public class NotificadorDeTemasNoTratados {
     }
 
     private String getLinkParaReProponer(TemaDeReunion unTemaDeReunion) {
-        return String.format("%s/reproponer-tema/%d", getHostName(), unTemaDeReunion.getPropuestaOriginal().getId());
+        return String.format("%s/reproponer-tema/%d", getHostName(), unTemaDeReunion.propuestaTratada().getId());
     }
 
     private String getHostName() {

--- a/backend/src/main/java/convention/persistent/Reunion.java
+++ b/backend/src/main/java/convention/persistent/Reunion.java
@@ -144,9 +144,9 @@ public class Reunion extends PersistableSupport {
                 });
     }
 
-    public Boolean tieneOtroTemaQueReProponeAlMismoQue(TemaDeReunionConDescripcion unTemaDeReunion) {
+    public Boolean tieneOtroTemaQueTrataLaMismaPropuestaQue(TemaDeReunionConDescripcion unTemaDeReunion) {
         return getTemasPropuestos().stream()
                 .filter(temaDeReunion -> !temaDeReunion.equals(unTemaDeReunion))
-                .anyMatch(temaDeReunion -> temaDeReunion.reProponeElMismoTemaQue(unTemaDeReunion));
+                .anyMatch(temaDeReunion -> temaDeReunion.trataLaMismaPropuestaQue(unTemaDeReunion));
     }
 }

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -24,7 +24,7 @@ public abstract class TemaDeReunion extends Tema {
     public static final String interesados_FIELD = "interesados";
     public static final String obligatoriedad_FIELD = "obligatoriedad";
     public static final String temaGenerador_FIELD = "temaGenerador";
-    public static final String primeraPropuesta_FIELD = "primeraPropuesta";
+    public static final String propuestaOriginal_FIELD = "propuestaOriginal";
     public static final String fechaDePrimeraPropuesta_FIELD = "fechaDePrimeraPropuesta";
     public static final String ERROR_AGREGAR_INTERESADO = "No se puede agregar un interesado a un tema obligatorio";
     @ManyToOne
@@ -38,7 +38,7 @@ public abstract class TemaDeReunion extends Tema {
     @ManyToOne
     private TemaGeneral temaGenerador;
     @ManyToOne
-    private TemaDeReunion primeraPropuesta;
+    private TemaDeReunion propuestaOriginal;
 
     public ObligatoriedadDeTema getObligatoriedad() {
         return obligatoriedad;
@@ -109,7 +109,7 @@ public abstract class TemaDeReunion extends Tema {
         copia.setDuracion(this.getDuracion());
         copia.setObligatoriedad(this.getObligatoriedad());
         copia.setUltimoModificador(this.getUltimoModificador());
-        copia.setPrimeraPropuesta(this.getPrimeraPropuesta());
+        copia.setPropuestaOriginal(this.getPropuestaOriginal());
         return copia;
     }
 
@@ -184,24 +184,24 @@ public abstract class TemaDeReunion extends Tema {
         return false;
     }
 
-    public void setPrimeraPropuesta(TemaDeReunion unTemaDeReunion) {
-        primeraPropuesta = unTemaDeReunion;
+    public void setPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
+        propuestaOriginal = unTemaDeReunion;
     }
 
-    public TemaDeReunion getPrimeraPropuesta() {
-        return Optional.ofNullable(primeraPropuesta).orElse(this);
+    public TemaDeReunion getPropuestaOriginal() {
+        return Optional.ofNullable(propuestaOriginal).orElse(this);
     }
 
     public Boolean esRePropuesta() {
-        return !Objects.equals(getPrimeraPropuesta(), this);
+        return !Objects.equals(getPropuestaOriginal(), this);
     }
 
     public Boolean reProponeElMismoTemaQue(TemaDeReunion otroTema) {
-        return Objects.equals(getPrimeraPropuesta(), otroTema.getPrimeraPropuesta());
+        return Objects.equals(getPropuestaOriginal(), otroTema.getPropuestaOriginal());
     }
 
     public LocalDate getFechaDePrimeraPropuesta() {
-        return getPrimeraPropuesta().getFechaDeReunion();
+        return getPropuestaOriginal().getFechaDeReunion();
     }
 
     private LocalDate getFechaDeReunion() {

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -26,6 +26,7 @@ public abstract class TemaDeReunion extends Tema {
     public static final String temaGenerador_FIELD = "temaGenerador";
     public static final String propuestaOriginal_FIELD = "propuestaOriginal";
     public static final String fechaDePropuestaOriginal_FIELD = "fechaDePropuestaOriginal";
+    public static final String esRePropuesta_FIELD = "esRePropuesta";
     public static final String ERROR_AGREGAR_INTERESADO = "No se puede agregar un interesado a un tema obligatorio";
     public static final String ERROR_PROPIA_PROPUESTA_ORIGINAL = "Un tema no puede ser su propia propuesta original";
     @ManyToOne
@@ -195,7 +196,7 @@ public abstract class TemaDeReunion extends Tema {
         return Optional.ofNullable(propuestaOriginal);
     }
 
-    public Boolean esRePropuesta() {
+    public Boolean getEsRePropuesta() {
         return !Objects.isNull(propuestaOriginal);
     }
 

--- a/backend/src/main/java/convention/persistent/TemaDeReunion.java
+++ b/backend/src/main/java/convention/persistent/TemaDeReunion.java
@@ -25,8 +25,9 @@ public abstract class TemaDeReunion extends Tema {
     public static final String obligatoriedad_FIELD = "obligatoriedad";
     public static final String temaGenerador_FIELD = "temaGenerador";
     public static final String propuestaOriginal_FIELD = "propuestaOriginal";
-    public static final String fechaDePrimeraPropuesta_FIELD = "fechaDePrimeraPropuesta";
+    public static final String fechaDePropuestaOriginal_FIELD = "fechaDePropuestaOriginal";
     public static final String ERROR_AGREGAR_INTERESADO = "No se puede agregar un interesado a un tema obligatorio";
+    public static final String ERROR_PROPIA_PROPUESTA_ORIGINAL = "Un tema no puede ser su propia propuesta original";
     @ManyToOne
     private Reunion reunion;
     private Integer prioridad;
@@ -184,27 +185,42 @@ public abstract class TemaDeReunion extends Tema {
         return false;
     }
 
-    public void setPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
-        propuestaOriginal = unTemaDeReunion;
+    private void verificarQueNoEsSuPropiaPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
+        if (equals(unTemaDeReunion)) {
+            throw new RuntimeException(ERROR_PROPIA_PROPUESTA_ORIGINAL);
+        }
     }
 
-    public TemaDeReunion getPropuestaOriginal() {
-        return Optional.ofNullable(propuestaOriginal).orElse(this);
+    public Optional<TemaDeReunion> propuestaOriginal() {
+        return Optional.ofNullable(propuestaOriginal);
     }
 
     public Boolean esRePropuesta() {
-        return !Objects.equals(getPropuestaOriginal(), this);
+        return !Objects.isNull(propuestaOriginal);
     }
 
-    public Boolean reProponeElMismoTemaQue(TemaDeReunion otroTema) {
-        return Objects.equals(getPropuestaOriginal(), otroTema.getPropuestaOriginal());
+    public TemaDeReunion propuestaTratada() {
+        return propuestaOriginal().orElse(this);
     }
 
-    public LocalDate getFechaDePrimeraPropuesta() {
-        return getPropuestaOriginal().getFechaDeReunion();
+    public Boolean trataLaMismaPropuestaQue(TemaDeReunion unTemaDeReunion) {
+        return propuestaTratada().equals(unTemaDeReunion.propuestaTratada());
+    }
+
+    public LocalDate getFechaDePropuestaOriginal() {
+        return Optional.ofNullable(propuestaOriginal).map(TemaDeReunion::getFechaDeReunion).orElse(null);
     }
 
     private LocalDate getFechaDeReunion() {
         return Optional.ofNullable(getReunion()).map(Reunion::getFecha).orElse(null);
+    }
+
+    public TemaDeReunion getPropuestaOriginal() {
+        return propuestaOriginal;
+    }
+
+    public void setPropuestaOriginal(TemaDeReunion unTemaDeReunion) {
+        verificarQueNoEsSuPropiaPropuestaOriginal(unTemaDeReunion);
+        propuestaOriginal = unTemaDeReunion;
     }
 }

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -108,7 +108,7 @@ public class TemaDeReunionResource {
     @Path("/{resourceId}")
     public void delete(@PathParam("resourceId") Long id) {
         TemaDeReunion tema = temaService.get(id);
-        temaService.convertirRePropuestasAPrimerasPropuestas(id);
+        temaService.convertirRePropuestasAPropuestasOriginales(id);
         temaService.delete(tema);
     }
 
@@ -137,7 +137,7 @@ public class TemaDeReunionResource {
     }
 
     private void verificarQueNoReProponeUnaRePropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {
-        if (unTemaDeReunion.getPrimeraPropuesta().esRePropuesta()) {
+        if (unTemaDeReunion.getPropuestaOriginal().esRePropuesta()) {
             throw new WebApplicationException("No se puede volver a proponer una re-propuesta", Response.Status.BAD_REQUEST);
         }
     }

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -138,7 +138,7 @@ public class TemaDeReunionResource {
 
     private void verificarQueNoReProponeUnaRePropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {
         unTemaDeReunion.propuestaOriginal().ifPresent(propuestaOriginal -> {
-            if (propuestaOriginal.esRePropuesta()) {
+            if (propuestaOriginal.getEsRePropuesta()) {
                 throw new WebApplicationException("No se puede volver a proponer una re-propuesta", Response.Status.BAD_REQUEST);
             }
         });

--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -127,7 +127,7 @@ public class TemaDeReunionResource {
     private void validarTemaDeReunionConDescripcion(TemaDeReunionConDescripcion nuevoTema) {
         verificarQueNoTieneTituloDeTemaParaProponerPinosARoot(nuevoTema);
         verificarQueNoReProponeUnaRePropuesta(nuevoTema);
-        verificarQueNoHayOtroTemaEnLaReunionQueReProponeAlMismoTema(nuevoTema);
+        verificarQueNoHayOtroTemaEnLaReunionQueTrataLaMismaPropuesta(nuevoTema);
     }
 
     private void verificarQueNoTieneTituloDeTemaParaProponerPinosARoot(TemaDeReunionConDescripcion unTemaDeReunion) {
@@ -137,13 +137,15 @@ public class TemaDeReunionResource {
     }
 
     private void verificarQueNoReProponeUnaRePropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {
-        if (unTemaDeReunion.getPropuestaOriginal().esRePropuesta()) {
-            throw new WebApplicationException("No se puede volver a proponer una re-propuesta", Response.Status.BAD_REQUEST);
-        }
+        unTemaDeReunion.propuestaOriginal().ifPresent(propuestaOriginal -> {
+            if (propuestaOriginal.esRePropuesta()) {
+                throw new WebApplicationException("No se puede volver a proponer una re-propuesta", Response.Status.BAD_REQUEST);
+            }
+        });
     }
 
-    private void verificarQueNoHayOtroTemaEnLaReunionQueReProponeAlMismoTema(TemaDeReunionConDescripcion unTemaDeReunion) {
-        if (unTemaDeReunion.getReunion().tieneOtroTemaQueReProponeAlMismoQue(unTemaDeReunion)) {
+    private void verificarQueNoHayOtroTemaEnLaReunionQueTrataLaMismaPropuesta(TemaDeReunionConDescripcion unTemaDeReunion) {
+        if (unTemaDeReunion.getReunion().tieneOtroTemaQueTrataLaMismaPropuestaQue(unTemaDeReunion)) {
             throw new WebApplicationException("No se puede volver a proponer el mismo tema más de una vez", Response.Status.CONFLICT);
         }
     }

--- a/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
@@ -44,6 +44,8 @@ public class TemaDeReunionTo extends PersistableToSupport {
     private Long idDePropuestaOriginal;
     @CopyFrom(TemaDeReunion.fechaDePropuestaOriginal_FIELD)
     private String fechaDePropuestaOriginal;
+    @CopyFrom(TemaDeReunion.esRePropuesta_FIELD)
+    private Boolean esRePropuesta;
 
     public String getAutor() {
       return autor;
@@ -139,5 +141,13 @@ public class TemaDeReunionTo extends PersistableToSupport {
 
     public void setFechaDePropuestaOriginal(String fechaDePropuestaOriginal) {
         this.fechaDePropuestaOriginal = fechaDePropuestaOriginal;
+    }
+
+    public Boolean getEsRePropuesta() {
+        return esRePropuesta;
+    }
+
+    public void setEsRePropuesta(Boolean esRePropuesta) {
+        this.esRePropuesta = esRePropuesta;
     }
 }

--- a/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
@@ -42,8 +42,8 @@ public class TemaDeReunionTo extends PersistableToSupport {
     private String obligatoriedad;
     @CopyFrom(TemaDeReunion.propuestaOriginal_FIELD)
     private Long idDePropuestaOriginal;
-    @CopyFrom(TemaDeReunion.fechaDePrimeraPropuesta_FIELD)
-    private String fechaDePrimeraPropuesta;
+    @CopyFrom(TemaDeReunion.fechaDePropuestaOriginal_FIELD)
+    private String fechaDePropuestaOriginal;
 
     public String getAutor() {
       return autor;
@@ -133,11 +133,11 @@ public class TemaDeReunionTo extends PersistableToSupport {
         this.idDePropuestaOriginal = idDePropuestaOriginal;
     }
 
-    public String getFechaDePrimeraPropuesta() {
-        return fechaDePrimeraPropuesta;
+    public String getFechaDePropuestaOriginal() {
+        return fechaDePropuestaOriginal;
     }
 
-    public void setFechaDePrimeraPropuesta(String fechaDePrimeraPropuesta) {
-        this.fechaDePrimeraPropuesta = fechaDePrimeraPropuesta;
+    public void setFechaDePropuestaOriginal(String fechaDePropuestaOriginal) {
+        this.fechaDePropuestaOriginal = fechaDePropuestaOriginal;
     }
 }

--- a/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaDeReunionTo.java
@@ -40,8 +40,8 @@ public class TemaDeReunionTo extends PersistableToSupport {
     private List<Long> idsDeInteresados;
     @CopyFromAndTo(TemaDeReunion.obligatoriedad_FIELD)
     private String obligatoriedad;
-    @CopyFrom(TemaDeReunion.primeraPropuesta_FIELD)
-    private Long idDePrimeraPropuesta;
+    @CopyFrom(TemaDeReunion.propuestaOriginal_FIELD)
+    private Long idDePropuestaOriginal;
     @CopyFrom(TemaDeReunion.fechaDePrimeraPropuesta_FIELD)
     private String fechaDePrimeraPropuesta;
 
@@ -125,12 +125,12 @@ public class TemaDeReunionTo extends PersistableToSupport {
       this.ultimoModificador = idDeUltimoModificador;
     }
 
-    public Long getIdDePrimeraPropuesta() {
-        return idDePrimeraPropuesta;
+    public Long getIdDePropuestaOriginal() {
+        return idDePropuestaOriginal;
     }
 
-    public void setIdDePrimeraPropuesta(Long idDePrimeraPropuesta) {
-        this.idDePrimeraPropuesta = idDePrimeraPropuesta;
+    public void setIdDePropuestaOriginal(Long idDePropuestaOriginal) {
+        this.idDePropuestaOriginal = idDePropuestaOriginal;
     }
 
     public String getFechaDePrimeraPropuesta() {

--- a/backend/src/main/java/convention/rest/api/tos/TemaEnCreacionTo.java
+++ b/backend/src/main/java/convention/rest/api/tos/TemaEnCreacionTo.java
@@ -29,8 +29,8 @@ public class TemaEnCreacionTo {
     @CopyTo(TemaDeReunion.obligatoriedad_FIELD)
     private String obligatoriedad;
 
-    @CopyTo(TemaDeReunion.primeraPropuesta_FIELD)
-    private Long idDePrimeraPropuesta;
+    @CopyTo(TemaDeReunion.propuestaOriginal_FIELD)
+    private Long idDePropuestaOriginal;
 
     public String getDuracion() {
         return duracion;
@@ -80,11 +80,11 @@ public class TemaEnCreacionTo {
         this.descripcion = descripcion;
     }
 
-    public void setIdDePrimeraPropuesta(Long idDePrimeraPropuesta) {
-        this.idDePrimeraPropuesta = idDePrimeraPropuesta;
+    public void setIdDePropuestaOriginal(Long idDePropuestaOriginal) {
+        this.idDePropuestaOriginal = idDePropuestaOriginal;
     }
 
-    public Long getIdDePrimeraPropuesta() {
-        return idDePrimeraPropuesta;
+    public Long getIdDePropuestaOriginal() {
+        return idDePropuestaOriginal;
     }
 }

--- a/backend/src/main/java/convention/services/ReunionService.java
+++ b/backend/src/main/java/convention/services/ReunionService.java
@@ -5,7 +5,6 @@ import ar.com.kfgodel.temas.acciones.UsarReunionExistente;
 import ar.com.kfgodel.temas.filters.reuniones.AllReunionesUltimaPrimero;
 import ar.com.kfgodel.temas.filters.reuniones.ProximaReunion;
 import ar.com.kfgodel.temas.filters.reuniones.UltimaReunion;
-import convention.persistent.Minuta;
 import convention.persistent.Reunion;
 
 import javax.inject.Inject;
@@ -49,7 +48,7 @@ public class ReunionService extends Service<Reunion> {
     Reunion reunion = get(id);
     reunion.getTemasPropuestos().stream()
             .filter(temaDeReunion -> !temaDeReunion.esRePropuesta())
-            .forEach(temaDeReunion -> temaService.convertirRePropuestasAPrimerasPropuestas(temaDeReunion.getId()));
+            .forEach(temaDeReunion -> temaService.convertirRePropuestasAPropuestasOriginales(temaDeReunion.getId()));
     super.delete(id);
   }
 

--- a/backend/src/main/java/convention/services/ReunionService.java
+++ b/backend/src/main/java/convention/services/ReunionService.java
@@ -47,7 +47,7 @@ public class ReunionService extends Service<Reunion> {
     minutaService.getForReunion(id).ifPresent(minutaService::delete);
     Reunion reunion = get(id);
     reunion.getTemasPropuestos().stream()
-            .filter(temaDeReunion -> !temaDeReunion.esRePropuesta())
+            .filter(temaDeReunion -> !temaDeReunion.getEsRePropuesta())
             .forEach(temaDeReunion -> temaService.convertirRePropuestasAPropuestasOriginales(temaDeReunion.getId()));
     super.delete(id);
   }

--- a/backend/src/main/java/convention/services/TemaService.java
+++ b/backend/src/main/java/convention/services/TemaService.java
@@ -2,7 +2,7 @@ package convention.services;
 
 import ar.com.kfgodel.orm.api.operations.basic.DeleteById;
 import ar.com.kfgodel.orm.api.operations.basic.FindAll;
-import ar.com.kfgodel.temas.acciones.ConvertirRePropuestasAPrimerasPropuestas;
+import ar.com.kfgodel.temas.acciones.ConvertirRePropuestasAPropuestasOriginales;
 import convention.persistent.StatusDeReunion;
 import convention.persistent.TemaDeReunion;
 import convention.persistent.TemaGeneral;
@@ -67,9 +67,9 @@ public class TemaService extends Service<TemaDeReunion> {
         }
     }
 
-    public void convertirRePropuestasAPrimerasPropuestas(Long id) {
+    public void convertirRePropuestasAPropuestasOriginales(Long id) {
         createOperation()
                 .insideATransaction()
-                .apply(ConvertirRePropuestasAPrimerasPropuestas.create(id));
+                .apply(ConvertirRePropuestasAPropuestasOriginales.create(id));
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -148,30 +147,30 @@ public class ReunionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testElGetDeReunionTieneLosIdsDePrimeraPropuestaCorrectos() throws IOException {
-        TemaDeReunion unaPrimeraPropuesta = temaService.save(helper.unTemaDeReunion());
+    public void testElGetDeReunionTieneLosIdsDePropuestaOriginalCorrectos() throws IOException {
+        TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
-        temaService.save(helper.unTemaDeReunionConPrimeraPropuestaParaReunion(unaPrimeraPropuesta, unaReunion));
+        temaService.save(helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
 
         HttpResponse response = makeGetRequest("reuniones/" + unaReunion.getId());
 
         JSONObject jsonResponse = new JSONObject(getResponseBody(response));
         JSONObject jsonDeLaRePropuesta = jsonResponse.getJSONArray("temasPropuestos").getJSONObject(0);
-        assertThat(jsonDeLaRePropuesta.getLong("idDePrimeraPropuesta")).isEqualTo(unaPrimeraPropuesta.getId());
+        assertThat(jsonDeLaRePropuesta.getLong("idDePropuestaOriginal")).isEqualTo(unaPropuestaOriginal.getId());
     }
 
     @Test
-    public void testCuandoSeEliminaUnaReunionConUnaPrimeraPropuestaSusRePropuestasDejanDeSerRePropuestas() throws IOException {
+    public void testCuandoSeEliminaUnaReunionConUnaPropuestaOriginalSusRePropuestasDejanDeSerRePropuestas() throws IOException {
         Reunion unaReunion = reunionService.save(helper.unaReunion());
-        TemaDeReunion unaPrimeraPropuesta = temaService.save(
+        TemaDeReunion unaPropuestaOriginal = temaService.save(
                 helper.unTemaDeReunion(unaReunion));
-        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunionConPrimeraPropuestaParaReunion(
-                unaPrimeraPropuesta, reunionService.save(helper.unaReunion())));
+        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunionConPropuestaOriginalParaReunion(
+                unaPropuestaOriginal, reunionService.save(helper.unaReunion())));
 
         HttpResponse response = makeDeleteRequest("reuniones/" + unaReunion.getId());
 
         assertThatResponseStatusCodeIs(response, HttpStatus.SC_NO_CONTENT);
-        assertThat(temaService.getAll()).doesNotContain(unaPrimeraPropuesta);
+        assertThat(temaService.getAll()).doesNotContain(unaPropuestaOriginal);
         assertThat(temaService.get(unTema.getId()).esRePropuesta()).isFalse();
     }
 

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
@@ -171,7 +171,7 @@ public class ReunionResourceTest extends ResourceTest {
 
         assertThatResponseStatusCodeIs(response, HttpStatus.SC_NO_CONTENT);
         assertThat(temaService.getAll()).doesNotContain(unaPropuestaOriginal);
-        assertThat(temaService.get(unTema.getId()).esRePropuesta()).isFalse();
+        assertThat(temaService.get(unTema.getId()).getEsRePropuesta()).isFalse();
     }
 
     private Usuario unUsuarioPersistido() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/ReunionResourceTest.java
@@ -150,7 +150,7 @@ public class ReunionResourceTest extends ResourceTest {
     public void testElGetDeReunionTieneLosIdsDePropuestaOriginalCorrectos() throws IOException {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
-        temaService.save(helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
+        temaService.save(helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
 
         HttpResponse response = makeGetRequest("reuniones/" + unaReunion.getId());
 
@@ -164,7 +164,7 @@ public class ReunionResourceTest extends ResourceTest {
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unaPropuestaOriginal = temaService.save(
                 helper.unTemaDeReunion(unaReunion));
-        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunionConPropuestaOriginalParaReunion(
+        TemaDeReunion unTema = temaService.save(helper.unaRePropuestaDeParaReunion(
                 unaPropuestaOriginal, reunionService.save(helper.unaReunion())));
 
         HttpResponse response = makeDeleteRequest("reuniones/" + unaReunion.getId());

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -90,76 +90,76 @@ public class TemaDeReunionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testUnTemaSeCreaConUnaPrimeraPropuesta() throws IOException {
+    public void testUnTemaSeCreaConUnaPropuestaOriginal() throws IOException {
         TemaDeReunionConDescripcion unTemaDeReunion = crearUnTemaDeReunionConDescripcion();
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
-        unTemaEnCreacionTo.setIdDePrimeraPropuesta(unTemaDeReunion.getId());
+        unTemaEnCreacionTo.setIdDePropuestaOriginal(unTemaDeReunion.getId());
 
         HttpResponse response = makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
 
         Long idDelTemaCreado = new JSONObject(getResponseBody(response)).getLong("id");
         TemaDeReunion temaCreado = temaService.get(idDelTemaCreado);
-        assertThat(temaCreado.getPrimeraPropuesta()).isEqualTo(unTemaDeReunion);
+        assertThat(temaCreado.getPropuestaOriginal()).isEqualTo(unTemaDeReunion);
     }
 
     @Test
-    public void testUnTemaSeCreaConsigoMismoComoPrimeraPropuestaSiNoSeEspecificaUna() throws IOException {
+    public void testUnTemaSeCreaConsigoMismoComoPropuestaOriginalSiNoSeEspecificaUna() throws IOException {
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
-        unTemaEnCreacionTo.setIdDePrimeraPropuesta(null);
+        unTemaEnCreacionTo.setIdDePropuestaOriginal(null);
 
         makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
 
         TemaDeReunion temaCreado = temaService.getAll().get(0);
-        assertThat(temaCreado.getPrimeraPropuesta()).isEqualTo(temaCreado);
+        assertThat(temaCreado.getPropuestaOriginal()).isEqualTo(temaCreado);
     }
 
     @Test
-    public void testGetDeTemasDeReunionContieneElIdDeLaPrimeraPropuesta() throws IOException {
+    public void testGetDeTemasDeReunionContieneElIdDeLaPropuestaOriginal() throws IOException {
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(helper.unTemaDeReunion(unaReunion));
 
         HttpResponse response = makeGetRequest("temas/" + unTema.getId());
 
         JSONObject jsonResponse = new JSONObject(getResponseBody(response));
-        assertThat(jsonResponse.getLong("idDePrimeraPropuesta")).isEqualTo(unTema.getPrimeraPropuesta().getId());
+        assertThat(jsonResponse.getLong("idDePropuestaOriginal")).isEqualTo(unTema.getPropuestaOriginal().getId());
     }
 
     @Test
-    public void testCrearUnTemaConUnaRePropuestaComoPrimeraPropuestaRetornaUnBadRequest() throws IOException {
-        TemaDeReunion unaPrimeraPropuesta = temaService.save(helper.unTemaDeReunion());
-        TemaDeReunion unaRePropuesta = temaService.save(helper.unTemaDeReunionConPrimeraPropuesta(unaPrimeraPropuesta));
+    public void testCrearUnTemaConUnaRePropuestaComoPropuestaOriginalRetornaUnBadRequest() throws IOException {
+        TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
+        TemaDeReunion unaRePropuesta = temaService.save(helper.unTemaDeReunionConPropuestaOriginal(unaPropuestaOriginal));
 
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
-        unTemaEnCreacionTo.setIdDePrimeraPropuesta(unaRePropuesta.getId());
+        unTemaEnCreacionTo.setIdDePropuestaOriginal(unaRePropuesta.getId());
 
         HttpResponse response = makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
 
         assertThatResponseStatusCodeIs(response, HttpStatus.SC_BAD_REQUEST);
-        assertThat(temaService.getAll()).containsExactly(unaPrimeraPropuesta, unaRePropuesta);
+        assertThat(temaService.getAll()).containsExactly(unaPropuestaOriginal, unaRePropuesta);
     }
 
     @Test
-    public void testNoSePuedeCrearMasDeUnTemaConLaMismaPrimeraPropuestaParaLaMismaReunion() throws IOException {
-        TemaDeReunion unaPrimeraPropuesta = temaService.save(helper.unTemaDeReunion());
+    public void testNoSePuedeCrearMasDeUnTemaConLaMismaPropuestaOriginalParaLaMismaReunion() throws IOException {
+        TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPrimeraPropuestaParaReunion(unaPrimeraPropuesta, unaReunion));
+                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
         reunionService.save(unaReunion);
 
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(unaReunion);
-        unTemaEnCreacionTo.setIdDePrimeraPropuesta(unaPrimeraPropuesta.getId());
+        unTemaEnCreacionTo.setIdDePropuestaOriginal(unaPropuestaOriginal.getId());
         HttpResponse response = makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
 
         assertThatResponseStatusCodeIs(response, HttpStatus.SC_CONFLICT);
-        assertThat(temaService.getAll()).containsExactly(unaPrimeraPropuesta, unTema);
+        assertThat(temaService.getAll()).containsExactly(unaPropuestaOriginal, unTema);
     }
 
     @Test
     public void testSePuedeModificarUnaRePropuesta() throws IOException {
-        TemaDeReunion unaPrimeraPropuesta = temaService.save(helper.unTemaDeReunion());
+        TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPrimeraPropuestaParaReunion(unaPrimeraPropuesta, unaReunion));
+                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
 
         TemaDeReunionTo toDelTema = convertirATo(unTema);
         String unNuevoTitulo = "Un nuevo título";
@@ -172,16 +172,16 @@ public class TemaDeReunionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testCuandoSeEliminaUnaPrimeraPropuestaSusRePropuestasDejanDeSerRePropuestas() throws IOException {
-        TemaDeReunion unaPrimeraPropuesta = temaService.save(helper.unTemaDeReunion());
+    public void testCuandoSeEliminaUnaPropuestaOriginalSusRePropuestasDejanDeSerRePropuestas() throws IOException {
+        TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPrimeraPropuestaParaReunion(unaPrimeraPropuesta, unaReunion));
+                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
 
-        HttpResponse response = makeDeleteRequest("temas/" + unaPrimeraPropuesta.getId());
+        HttpResponse response = makeDeleteRequest("temas/" + unaPropuestaOriginal.getId());
 
         assertThatResponseStatusCodeIs(response, HttpStatus.SC_NO_CONTENT);
-        assertThat(temaService.getAll()).doesNotContain(unaPrimeraPropuesta);
+        assertThat(temaService.getAll()).doesNotContain(unaPropuestaOriginal);
         assertThat(temaService.get(unTema.getId()).esRePropuesta()).isFalse();
     }
     

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -90,44 +90,34 @@ public class TemaDeReunionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testUnTemaSeCreaConUnaPropuestaOriginal() throws IOException {
-        TemaDeReunionConDescripcion unTemaDeReunion = crearUnTemaDeReunionConDescripcion();
+    public void testUnaRePropuestaSeCreaCreandoUnTemaConUnaPropuestaOriginal() throws IOException {
+        TemaDeReunionConDescripcion unaPropuestaOriginal = crearUnTemaDeReunionConDescripcion();
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
-        unTemaEnCreacionTo.setIdDePropuestaOriginal(unTemaDeReunion.getId());
+        unTemaEnCreacionTo.setIdDePropuestaOriginal(unaPropuestaOriginal.getId());
 
         HttpResponse response = makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
 
         Long idDelTemaCreado = new JSONObject(getResponseBody(response)).getLong("id");
         TemaDeReunion temaCreado = temaService.get(idDelTemaCreado);
-        assertThat(temaCreado.getPropuestaOriginal()).isEqualTo(unTemaDeReunion);
+        assertThat(temaCreado.propuestaOriginal().get()).isEqualTo(unaPropuestaOriginal);
     }
 
     @Test
-    public void testUnTemaSeCreaConsigoMismoComoPropuestaOriginalSiNoSeEspecificaUna() throws IOException {
-        TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
-        unTemaEnCreacionTo.setIdDePropuestaOriginal(null);
-
-        makeJsonPostRequest("temas/", convertirAJsonString(unTemaEnCreacionTo));
-
-        TemaDeReunion temaCreado = temaService.getAll().get(0);
-        assertThat(temaCreado.getPropuestaOriginal()).isEqualTo(temaCreado);
-    }
-
-    @Test
-    public void testGetDeTemasDeReunionContieneElIdDeLaPropuestaOriginal() throws IOException {
+    public void testGetDeUnaRePropuestaContieneElIdDeLaPropuestaOriginal() throws IOException {
+        TemaDeReunionConDescripcion unaPropuestaOriginal = crearUnTemaDeReunionConDescripcion();
         Reunion unaReunion = reunionService.save(helper.unaReunion());
-        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunion(unaReunion));
+        TemaDeReunion unTema = temaService.save(helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
 
         HttpResponse response = makeGetRequest("temas/" + unTema.getId());
 
         JSONObject jsonResponse = new JSONObject(getResponseBody(response));
-        assertThat(jsonResponse.getLong("idDePropuestaOriginal")).isEqualTo(unTema.getPropuestaOriginal().getId());
+        assertThat(jsonResponse.getLong("idDePropuestaOriginal")).isEqualTo(unaPropuestaOriginal.getId());
     }
 
     @Test
     public void testCrearUnTemaConUnaRePropuestaComoPropuestaOriginalRetornaUnBadRequest() throws IOException {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
-        TemaDeReunion unaRePropuesta = temaService.save(helper.unTemaDeReunionConPropuestaOriginal(unaPropuestaOriginal));
+        TemaDeReunion unaRePropuesta = temaService.save(helper.unaRePropuestaDe(unaPropuestaOriginal));
 
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(reunionService.save(helper.unaReunion()));
         unTemaEnCreacionTo.setIdDePropuestaOriginal(unaRePropuesta.getId());
@@ -143,7 +133,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
+                helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
         reunionService.save(unaReunion);
 
         TemaEnCreacionTo unTemaEnCreacionTo = helper.unTemaEnCreacionTo(unaReunion);
@@ -159,7 +149,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
+                helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
 
         TemaDeReunionTo toDelTema = convertirATo(unTema);
         String unNuevoTitulo = "Un nuevo título";
@@ -176,7 +166,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion());
         Reunion unaReunion = reunionService.save(helper.unaReunion());
         TemaDeReunion unTema = temaService.save(
-                helper.unTemaDeReunionConPropuestaOriginalParaReunion(unaPropuestaOriginal, unaReunion));
+                helper.unaRePropuestaDeParaReunion(unaPropuestaOriginal, unaReunion));
 
         HttpResponse response = makeDeleteRequest("temas/" + unaPropuestaOriginal.getId());
 
@@ -186,17 +176,16 @@ public class TemaDeReunionResourceTest extends ResourceTest {
     }
     
     @Test
-    public void testGetDeTemasDeReunionContieneLaFechaDeLaPrimeraPropuesta() throws IOException {
+    public void testGetDeTemasDeReunionContieneLaFechaDeLaPropuestaOriginal() throws IOException {
         Reunion unaReunion = reunionService.save(helper.unaReunion());
-        TemaDeReunion unTema = helper.unTemaDeReunion();
-        unTema.setReunion(unaReunion);
-        unTema = temaService.save(unTema);
+        TemaDeReunion unaPropuestaOriginal = temaService.save(helper.unTemaDeReunion(unaReunion));
+        TemaDeReunion unTema = temaService.save(helper.unaRePropuestaDe(unaPropuestaOriginal));
 
         HttpResponse response = makeGetRequest("temas/" + unTema.getId());
 
         JSONObject jsonResponse = new JSONObject(getResponseBody(response));
-        String fechaDeLaPrimeraPropuesta = convertirA(unTema.getFechaDePrimeraPropuesta(), String.class);
-        assertThat(jsonResponse.getString("fechaDePrimeraPropuesta")).isEqualTo(fechaDeLaPrimeraPropuesta);
+        String fechaDeLaPropuestaOriginal = convertirA(unTema.getFechaDePropuestaOriginal(), String.class);
+        assertThat(jsonResponse.getString("fechaDePropuestaOriginal")).isEqualTo(fechaDeLaPropuestaOriginal);
     }
 
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -172,7 +172,7 @@ public class TemaDeReunionResourceTest extends ResourceTest {
 
         assertThatResponseStatusCodeIs(response, HttpStatus.SC_NO_CONTENT);
         assertThat(temaService.getAll()).doesNotContain(unaPropuestaOriginal);
-        assertThat(temaService.get(unTema.getId()).esRePropuesta()).isFalse();
+        assertThat(temaService.get(unTema.getId()).getEsRePropuesta()).isFalse();
     }
     
     @Test
@@ -186,6 +186,16 @@ public class TemaDeReunionResourceTest extends ResourceTest {
         JSONObject jsonResponse = new JSONObject(getResponseBody(response));
         String fechaDeLaPropuestaOriginal = convertirA(unTema.getFechaDePropuestaOriginal(), String.class);
         assertThat(jsonResponse.getString("fechaDePropuestaOriginal")).isEqualTo(fechaDeLaPropuestaOriginal);
+    }
+
+    @Test
+    public void testGetDeTemasDeReunionDiceSiEsUnaRePropuesta() throws IOException {
+        TemaDeReunion unTema = temaService.save(helper.unTemaDeReunion());
+
+        HttpResponse response = makeGetRequest("temas/" + unTema.getId());
+
+        JSONObject jsonResponse = new JSONObject(getResponseBody(response));
+        assertThat(jsonResponse.getBoolean("esRePropuesta")).isFalse();
     }
 
     private TemaDeReunionConDescripcion crearUnTemaDeReunionConDescripcion() {

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -208,7 +208,7 @@ public class TemaDeReunionTest {
         TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
         TemaDeReunion unaRepropuesta = helper.unaRePropuestaDe(unaPropuestaOriginal);
 
-        assertThat(unaRepropuesta.esRePropuesta()).isTrue();
+        assertThat(unaRepropuesta.getEsRePropuesta()).isTrue();
     }
 
     @Test
@@ -216,7 +216,7 @@ public class TemaDeReunionTest {
         TemaDeReunion unTema = helper.unTemaDeReunion();
         unTema.setPropuestaOriginal(null);
 
-        assertThat(unTema.esRePropuesta()).isFalse();
+        assertThat(unTema.getEsRePropuesta()).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 
 import static junit.framework.TestCase.fail;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.Is.is;
 
 /**
@@ -199,42 +200,54 @@ public class TemaDeReunionTest {
         TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
         TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
 
-        assertThat(unTema.getPropuestaOriginal()).isEqualTo(unaPropuestaOriginal);
+        assertThat(unTema.propuestaOriginal().get()).isEqualTo(unaPropuestaOriginal);
     }
 
     @Test
     public void testUnTemaEsUnaRePropuestaSiSuPropuestaOriginalEsOtroTemaDistinto() {
         TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
+        TemaDeReunion unaRepropuesta = helper.unaRePropuestaDe(unaPropuestaOriginal);
 
-        assertThat(unTema.esRePropuesta()).isTrue();
+        assertThat(unaRepropuesta.esRePropuesta()).isTrue();
     }
 
     @Test
-    public void testUnTemaNoEsRePropuestaSiSuPropuestaOriginalEsElMismo() {
+    public void testUnTemaNoEsRePropuestaSiSuPropuestaOriginalNoEsOtroTemaDistinto() {
         TemaDeReunion unTema = helper.unTemaDeReunion();
-        unTema.setPropuestaOriginal(unTema);
+        unTema.setPropuestaOriginal(null);
 
         assertThat(unTema.esRePropuesta()).isFalse();
     }
 
     @Test
-    public void testDosTemasReProponenElMismoTemaSiSuPropuestaOriginalSonLaMisma() {
-        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
-        TemaDeReunion otroTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
+    public void testLaPropuestaOriginalDeUnTemaNoPuedeSerElMismo() {
+        TemaDeReunion unTema = helper.unTemaDeReunion();
 
-        assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isTrue();
+        assertThatThrownBy(() -> {
+            unTema.setPropuestaOriginal(unTema);
+        }).hasMessage(TemaDeReunion.ERROR_PROPIA_PROPUESTA_ORIGINAL);
     }
 
     @Test
-    public void testDosTemasNoReProponenElMismoTemaSiSuPropuestaOriginalEsDistinta() {
-        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
-        TemaDeReunion otraPropuestaOriginal = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
-        TemaDeReunion otroTema = helper.unaRePropuestaDe(otraPropuestaOriginal);
+    public void testLaPropuestaTratadaDeUnaRePropuestaEsSuPropuestaOriginal() {
+        TemaDeReunion unaRePropuesta = helper.unaRePropuesta();
 
-        assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isFalse();
+        assertThat(unaRePropuesta.propuestaTratada()).isEqualTo(unaRePropuesta.propuestaOriginal().get());
+    }
+
+    @Test
+    public void testLaPropuestaTratadaDeUnTemaOriginalEsElMismo() {
+        TemaDeReunion unTemaOriginal = helper.unTemaDeReunion();
+
+        assertThat(unTemaOriginal.propuestaTratada()).isEqualTo(unTemaOriginal);
+    }
+
+    @Test
+    public void testDosTemasTratanLaMismaPropuestaSiSuPropuestaTratadaEsLaMisma() {
+        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
+
+        assertThat(unaPropuestaOriginal.trataLaMismaPropuestaQue(unTema)).isTrue();
     }
 
     @Test
@@ -243,6 +256,6 @@ public class TemaDeReunionTest {
         TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion(unaReunion);
         TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
 
-        assertThat(unTema.getFechaDePrimeraPropuesta()).isEqualTo(unaReunion.getFecha());
+        assertThat(unTema.getFechaDePropuestaOriginal()).isEqualTo(unaReunion.getFecha());
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/domain/TemaDeReunionTest.java
@@ -195,44 +195,44 @@ public class TemaDeReunionTest {
     }
 
     @Test
-    public void test20LosTemasTienenUnaPrimeraPropuesta() {
-        TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
+    public void test20LosTemasTienenUnaPropuestaOriginal() {
+        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
 
-        assertThat(unTema.getPrimeraPropuesta()).isEqualTo(unaPrimeraPropuesta);
+        assertThat(unTema.getPropuestaOriginal()).isEqualTo(unaPropuestaOriginal);
     }
 
     @Test
-    public void testUnTemaEsUnaRePropuestaSiSuPrimeraPropuestaEsOtroTemaDistinto() {
-        TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
+    public void testUnTemaEsUnaRePropuestaSiSuPropuestaOriginalEsOtroTemaDistinto() {
+        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
 
         assertThat(unTema.esRePropuesta()).isTrue();
     }
 
     @Test
-    public void testUnTemaNoEsRePropuestaSiSuPrimeraPropuestaEsElMismo() {
+    public void testUnTemaNoEsRePropuestaSiSuPropuestaOriginalEsElMismo() {
         TemaDeReunion unTema = helper.unTemaDeReunion();
-        unTema.setPrimeraPropuesta(unTema);
+        unTema.setPropuestaOriginal(unTema);
 
         assertThat(unTema.esRePropuesta()).isFalse();
     }
 
     @Test
-    public void testDosTemasReProponenElMismoTemaSiSuPrimeraPropuestaSonLaMisma() {
-        TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
-        TemaDeReunion otroTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
+    public void testDosTemasReProponenElMismoTemaSiSuPropuestaOriginalSonLaMisma() {
+        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
+        TemaDeReunion otroTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
 
         assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isTrue();
     }
 
     @Test
-    public void testDosTemasNoReProponenElMismoTemaSiSuPrimeraPropuestaEsDistinta() {
-        TemaDeReunion unaPrimeraPropuesta = helper.unTemaDeReunion();
-        TemaDeReunion otraPrimeraPropuesta = helper.unTemaDeReunion();
-        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPrimeraPropuesta);
-        TemaDeReunion otroTema = helper.unaRePropuestaDe(otraPrimeraPropuesta);
+    public void testDosTemasNoReProponenElMismoTemaSiSuPropuestaOriginalEsDistinta() {
+        TemaDeReunion unaPropuestaOriginal = helper.unTemaDeReunion();
+        TemaDeReunion otraPropuestaOriginal = helper.unTemaDeReunion();
+        TemaDeReunion unTema = helper.unaRePropuestaDe(unaPropuestaOriginal);
+        TemaDeReunion otroTema = helper.unaRePropuestaDe(otraPropuestaOriginal);
 
         assertThat(unTema.reProponeElMismoTemaQue(otroTema)).isFalse();
     }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -229,14 +229,19 @@ public class TestHelper {
         return typeTransformer.transformTo(unaClaseDestino, unObjeto);
     }
 
-    public TemaDeReunion unTemaDeReunionConPropuestaOriginal(TemaDeReunion unaPropuestaOriginal) {
+    public TemaDeReunion unaRePropuesta() {
+        TemaDeReunion unaPropuestaOriginal = unTemaDeReunion();
+        return unaRePropuestaDe(unaPropuestaOriginal);
+    }
+
+    public TemaDeReunion unaRePropuestaDe(TemaDeReunion unaPropuestaOriginal) {
         TemaDeReunion unTemaDeReunion = unTemaDeReunion();
         unTemaDeReunion.setPropuestaOriginal(unaPropuestaOriginal);
         return unTemaDeReunion;
     }
 
-    public TemaDeReunion unTemaDeReunionConPropuestaOriginalParaReunion(TemaDeReunion unaPropuestaOriginal, Reunion unaReunion) {
-        TemaDeReunion unTemaDeReunion = unTemaDeReunionConPropuestaOriginal(unaPropuestaOriginal);
+    public TemaDeReunion unaRePropuestaDeParaReunion(TemaDeReunion unaPropuestaOriginal, Reunion unaReunion) {
+        TemaDeReunion unTemaDeReunion = unaRePropuestaDe(unaPropuestaOriginal);
         unTemaDeReunion.setReunion(unaReunion);
         return unTemaDeReunion;
     }
@@ -244,12 +249,6 @@ public class TestHelper {
     public TemaDeReunion unTemaDeReunion(Reunion unaReunion) {
         TemaDeReunion unTemaDeReunion = unTemaDeReunion();
         unTemaDeReunion.setReunion(unaReunion);
-        return unTemaDeReunion;
-    }
-
-    public TemaDeReunion unaRePropuestaDe(TemaDeReunion unaPrimeraPropuesta) {
-        TemaDeReunion unTemaDeReunion = unTemaDeReunion();
-        unTemaDeReunion.setPropuestaOriginal(unaPrimeraPropuesta);
         return unTemaDeReunion;
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -229,14 +229,14 @@ public class TestHelper {
         return typeTransformer.transformTo(unaClaseDestino, unObjeto);
     }
 
-    public TemaDeReunion unTemaDeReunionConPrimeraPropuesta(TemaDeReunion unaPrimeraPropuesta) {
+    public TemaDeReunion unTemaDeReunionConPropuestaOriginal(TemaDeReunion unaPropuestaOriginal) {
         TemaDeReunion unTemaDeReunion = unTemaDeReunion();
-        unTemaDeReunion.setPrimeraPropuesta(unaPrimeraPropuesta);
+        unTemaDeReunion.setPropuestaOriginal(unaPropuestaOriginal);
         return unTemaDeReunion;
     }
 
-    public TemaDeReunion unTemaDeReunionConPrimeraPropuestaParaReunion(TemaDeReunion unaPrimeraPropuesta, Reunion unaReunion) {
-        TemaDeReunion unTemaDeReunion = unTemaDeReunionConPrimeraPropuesta(unaPrimeraPropuesta);
+    public TemaDeReunion unTemaDeReunionConPropuestaOriginalParaReunion(TemaDeReunion unaPropuestaOriginal, Reunion unaReunion) {
+        TemaDeReunion unTemaDeReunion = unTemaDeReunionConPropuestaOriginal(unaPropuestaOriginal);
         unTemaDeReunion.setReunion(unaReunion);
         return unTemaDeReunion;
     }
@@ -249,7 +249,7 @@ public class TestHelper {
 
     public TemaDeReunion unaRePropuestaDe(TemaDeReunion unaPrimeraPropuesta) {
         TemaDeReunion unTemaDeReunion = unTemaDeReunion();
-        unTemaDeReunion.setPrimeraPropuesta(unaPrimeraPropuesta);
+        unTemaDeReunion.setPropuestaOriginal(unaPrimeraPropuesta);
         return unTemaDeReunion;
     }
 }

--- a/backend/src/test/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratadosTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratadosTest.java
@@ -94,7 +94,7 @@ public class NotificadorDeTemasNoTratadosTest {
         assertThat(remitente.getName()).isEqualTo("Aviso Tema No Propuesto");
         assertThat(remitente.getAddress()).isEqualTo(MailerConfiguration.getSenderAdress());
         assertThat(emailEnviado.getSubject()).isEqualTo(String.format("Tu tema \"%s\" no fue tratado", tituloDelTema));
-        String linkParaReproponerTema = String.format("%s/reproponer-tema/%d", getHostName(), temaNoTratado.getPrimeraPropuesta().getId());
+        String linkParaReproponerTema = String.format("%s/reproponer-tema/%d", getHostName(), temaNoTratado.getPropuestaOriginal().getId());
         assertThat(emailEnviado.getPlainText()).isEqualTo(
                 String.format("Hola! El tema \"%s\" que presentaste en la roots pasada no fue tratado. " +
                                 "Sentite libre de volver a proponerlo con este link %s",

--- a/backend/src/test/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratadosTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/notifications/NotificadorDeTemasNoTratadosTest.java
@@ -94,7 +94,7 @@ public class NotificadorDeTemasNoTratadosTest {
         assertThat(remitente.getName()).isEqualTo("Aviso Tema No Propuesto");
         assertThat(remitente.getAddress()).isEqualTo(MailerConfiguration.getSenderAdress());
         assertThat(emailEnviado.getSubject()).isEqualTo(String.format("Tu tema \"%s\" no fue tratado", tituloDelTema));
-        String linkParaReproponerTema = String.format("%s/reproponer-tema/%d", getHostName(), temaNoTratado.getPropuestaOriginal().getId());
+        String linkParaReproponerTema = String.format("%s/reproponer-tema/%d", getHostName(), temaNoTratado.propuestaTratada().getId());
         assertThat(emailEnviado.getPlainText()).isEqualTo(
                 String.format("Hola! El tema \"%s\" que presentaste en la roots pasada no fue tratado. " +
                                 "Sentite libre de volver a proponerlo con este link %s",

--- a/frontend/app/components/header-tema.js
+++ b/frontend/app/components/header-tema.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
     if (this.get('antiguedadRelativa')){
       return this.tema.get('antiguedadDePropuesta');
     } else {
-      return "el " + this.tema.get('fechaDePrimeraPropuesta');
+      return "el " + this.tema.get('fechaDePropuestaOriginal');
     }
   })
 });

--- a/frontend/app/concepts/tema.js
+++ b/frontend/app/concepts/tema.js
@@ -59,8 +59,8 @@ export default Ember.Object.extend({
     return this.get('id') !== this.get('idDePrimeraPropuesta');
   }),
 
-  antiguedadDePropuesta: Ember.computed('fechaDePrimeraPropuesta', function () {
-    return moment(this.get('fechaDePrimeraPropuesta')).locale('es').fromNow();
+  antiguedadDePropuesta: Ember.computed('fechaDePropuestaOriginal', function () {
+    return moment(this.get('fechaDePropuestaOriginal')).locale('es').fromNow();
   }),
 
   agregarInteresado(idDeInteresado) {

--- a/frontend/app/concepts/tema.js
+++ b/frontend/app/concepts/tema.js
@@ -55,8 +55,8 @@ export default Ember.Object.extend({
     return obligatoriedad === "OBLIGATORIO" || obligatoriedad === "OBLIGATORIO_GENERAL";
   }),
 
-  esRepropuesta: Ember.computed('id', 'idDePrimeraPropuesta', function(){
-    return this.get('id') !== this.get('idDePrimeraPropuesta');
+  esRePropuesta: Ember.computed('esRePropuesta', function(){
+    return this.get('esRePropuesta');
   }),
 
   antiguedadDePropuesta: Ember.computed('fechaDePropuestaOriginal', function () {

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -226,7 +226,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
             this.set('nuevoTema', Tema.create({
               idDeReunion: this._idDeReunion(),
               idDeAutor: this._idDeUsuarioActual(),
-              idDePropuestaOriginal: tema.idDePropuestaOriginal,
+              idDePropuestaOriginal: tema.esRepropuesta ? tema.idDePropuestaOriginal : tema.id,
               duracion: tema.duracion,
               titulo: tema.titulo,
               descripcion: tema.descripcion,

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -186,7 +186,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
           this._traerDuraciones().then(() => {
             this.set('temaAEditar', Tema.create({}));
             this.set('temaAEditar.id', tema.id);
-            this.set('temaAEditar.idDePrimeraPropuesta', tema.idDePrimeraPropuesta);
+            this.set('temaAEditar.idDePropuestaOriginal', tema.idDePropuestaOriginal);
             this.set('temaAEditar.tipo', tema.tipo);
             this.set('temaAEditar.duracion', tema.duracion);
             this.set('temaAEditar.idDeAutor', tema.idDeAutor);
@@ -226,7 +226,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
             this.set('nuevoTema', Tema.create({
               idDeReunion: this._idDeReunion(),
               idDeAutor: this._idDeUsuarioActual(),
-              idDePrimeraPropuesta: tema.idDePrimeraPropuesta,
+              idDePropuestaOriginal: tema.idDePropuestaOriginal,
               duracion: tema.duracion,
               titulo: tema.titulo,
               descripcion: tema.descripcion,

--- a/frontend/app/controllers/reuniones/edit.js
+++ b/frontend/app/controllers/reuniones/edit.js
@@ -226,7 +226,7 @@ export default Ember.Controller.extend(ReunionServiceInjected, TemaServiceInject
             this.set('nuevoTema', Tema.create({
               idDeReunion: this._idDeReunion(),
               idDeAutor: this._idDeUsuarioActual(),
-              idDePropuestaOriginal: tema.esRepropuesta ? tema.idDePropuestaOriginal : tema.id,
+              idDePropuestaOriginal: tema.esRePropuesta ? tema.idDePropuestaOriginal : tema.id,
               duracion: tema.duracion,
               titulo: tema.titulo,
               descripcion: tema.descripcion,

--- a/frontend/app/templates/components/header-tema.hbs
+++ b/frontend/app/templates/components/header-tema.hbs
@@ -1,7 +1,7 @@
 <div class="space-between align-center">
   <h5 class="titulo-de-tema no-margin">{{tema.titulo}} </h5>
   <div class="flex-center">
-    {{#if tema.esRepropuesta}}
+    {{#if tema.esRePropuesta}}
       <h6 class="no-margin text-gray text-small">Propuesto originalmente {{antiguedad}}</h6>
     {{/if}}
     {{#if mostrarFlagActionItems}}


### PR DESCRIPTION
1. Renombra "primera propuesta" a "propuesta original" https://github.com/10PinesLabs/votacion-roots/pull/166
2. Hace que solo las re-propuestas tengan una propuesta original https://github.com/10PinesLabs/votacion-roots/pull/171
3. Agrega un atributo esRePropuesta al json de tema de reunión https://github.com/10PinesLabs/votacion-roots/pull/172