### PR TITLE
Hace que no se repita "reuniones" en la ruta para ver una reunión

### DIFF
--- a/frontend/app/components/detalle-de-reunion.js
+++ b/frontend/app/components/detalle-de-reunion.js
@@ -59,7 +59,7 @@ export default Ember.Component.extend(NavigatorInjected, ReunionServiceInjected,
     compartirReunion(reunion) {
       const baseUrl = window.location.host;
       const minutaUrl = baseUrl + "/minuta/" + reunion.id + "/ver";
-      const reunionUrl = baseUrl + '/reuniones/reuniones/' + reunion.id;
+      const reunionUrl = baseUrl + '/reuniones/' + reunion.id;
 
       const linkToShare = reunion.status === estadoDeReunion.PENDIENTE ? reunionUrl : minutaUrl ;
 

--- a/frontend/app/router.js
+++ b/frontend/app/router.js
@@ -13,7 +13,7 @@ Router.map(function () {
   this.route('proxima-roots');
   this.route('reproponer-tema', {path: "reproponer-tema/:id"});
   this.route('reuniones', function () {
-    this.route('edit', {path: "reuniones/:reunion_id"});
+    this.route('edit', {path: ":reunion_id"});
     this.route('list');
   });
   this.route('minuta', function(){

--- a/frontend/app/templates/components/navigation-bar.hbs
+++ b/frontend/app/templates/components/navigation-bar.hbs
@@ -10,7 +10,7 @@
       <li class="tab">
         <div class="vertical-divisor"/>
       </li>
-      {{opcion-header link-to='proxima-roots' route='/reuniones/reuniones/' title='Proxima Roots'}}
+      {{opcion-header link-to='proxima-roots' route='/reuniones/' title='Proxima Roots'}}
       {{opcion-header link-to='reuniones.list' route='/reuniones/list' title='Reuniones'}}
       {{opcion-header link-to='temas-generales' route='/temas-generales' title='Temas Generales'}}
       {{opcion-header link-to='minuta.ultima-minuta' route='/minuta/ultima' title='Última minuta'}}
@@ -29,7 +29,7 @@
 <div class="mobile-bar">
   <div class="mobile-bar__menu">
     {{#tenpines/drop-down class="mobile-menu-styled" icon='menu'}}
-      {{opcion-header link-to='proxima-roots' route='/reuniones/reuniones/' title='Proxima Roots'}}
+      {{opcion-header link-to='proxima-roots' route='/reuniones/' title='Proxima Roots'}}
       {{opcion-header link-to='reuniones.list' route='/reuniones/list' title='Reuniones'}}
       {{opcion-header link-to='temas-generales' route='/temas-generales' title='Temas Generales'}}
       {{opcion-header link-to='minuta.ultima-minuta' route='/minuta/ultima' title='Última minuta'}}


### PR DESCRIPTION
Cambia la ruta para ver una reunión de `/reuniones/reuniones/:id` a `/reuniones/:id`