### PR TITLE
No muestra el menu para editar/eliminar un tema cuando la reunión está cerrada

### DIFF
--- a/frontend/app/templates/components/each-card-tema.hbs
+++ b/frontend/app/templates/components/each-card-tema.hbs
@@ -43,17 +43,19 @@
           <i class="material-icons m-5">access_time</i>
           <div class={{tema.colorDuracion}}>{{tema.duracion}}</div>
         </div>
-        <div class="reunion__body__temas__detalles__datos__item" id="edit-menu">
-          {{#tenpines/drop-down icon='more_vert' removeBtn=true }}
-            {{#unless tema.esTemaParaProponerPinos}}
-              <li class="light-grey" {{action mostrarFormularioDeEdicion tema}}>
-                <a class="black-text">Editar</a>
-              </li>
-            {{/unless}}
-            <li class="divider"></li>
-            <li class="light-grey"><a class="black-text" {{action borrarTemaElegido tema}}>Eliminar</a></li>
-          {{/tenpines/drop-down }}
-        </div>
+        {{#unless estaCerrada}}
+          <div class="reunion__body__temas__detalles__datos__item" id="edit-menu">
+            {{#tenpines/drop-down icon='more_vert' removeBtn=true }}
+              {{#unless tema.esTemaParaProponerPinos}}
+                <li class="light-grey" {{action mostrarFormularioDeEdicion tema}}>
+                  <a class="black-text">Editar</a>
+                </li>
+              {{/unless}}
+              <li class="divider"></li>
+              <li class="light-grey"><a class="black-text" {{action borrarTemaElegido tema}}>Eliminar</a></li>
+            {{/tenpines/drop-down }}
+          </div>
+        {{/unless}}
       </div>
 
 


### PR DESCRIPTION
Antes:
![2020-01-28T16:16:22-03:00](https://user-images.githubusercontent.com/46203110/73297176-d7af5980-41e9-11ea-8d50-64825db16bdb.png)

Ahora:
![2020-01-28T16:16:42-03:00](https://user-images.githubusercontent.com/46203110/73297177-d7af5980-41e9-11ea-80a5-28f3624f3a4b.png)