### PR TITLE
TemaDeReunionResource: fix: no se setea el momento de creación al crearse un tema

### DIFF
--- a/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
+++ b/backend/src/main/java/convention/rest/api/TemaDeReunionResource.java
@@ -33,7 +33,8 @@ public class TemaDeReunionResource {
         TemaDeReunionConDescripcion temaCreado = getResourceHelper().convertir(newState, TemaDeReunionConDescripcion.class);
         validarTemaDeReunionConDescripcion(temaCreado);
         temaCreado.setUltimoModificador(getResourceHelper().usuarioActual(securityContext));
-        return temaService.saving(temaCreado).convertTo(TemaDeReunionTo.class);
+        TemaDeReunion temaDeReunion = temaService.save(temaCreado);
+        return getResourceHelper().convertir(temaDeReunion, TemaDeReunionTo.class);
     }
 
     @PUT

--- a/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/apiRest/TemaDeReunionResourceTest.java
@@ -9,12 +9,32 @@ import org.json.JSONObject;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TemaDeReunionResourceTest extends ResourceTest {
 
     public static final String CAMPO_DE_TIPO = "tipo";
+
+    @Test
+    public void postDeTemaDeReunionCreaElTema() throws IOException {
+        Reunion reunion = reunionService.save(helper.unaReunion());
+        TemaEnCreacionTo temaEnCreacionTo = helper.unTemaEnCreacionTo(reunion);
+
+        HttpResponse response = makeJsonPostRequest("temas", convertirAJsonString(temaEnCreacionTo));
+
+        List<TemaDeReunion> temas = temaService.getAll();
+        assertThat(temas).hasSize(1);
+        assertThat(temas).first().satisfies(temaDeReunion -> {
+            assertThat(temaDeReunion.getTitulo()).isEqualTo(temaEnCreacionTo.getTitulo());
+            assertThat(temaDeReunion.getDescripcion()).isEqualTo(temaEnCreacionTo.getDescripcion());
+            assertThat(temaDeReunion.getDuracion().getNombre()).isEqualTo(temaEnCreacionTo.getDuracion());
+            assertThat(temaDeReunion.getObligatoriedad().name()).isEqualTo(temaEnCreacionTo.getObligatoriedad());
+            assertThat(temaDeReunion.getMomentoDeCreacion()).isNotNull();
+        });
+        assertThatResponseStatusCodeIs(response, HttpStatus.SC_OK);
+    }
 
     @Test
     public void testGetDeTemaDeReunionContieneElTipoDeTemaParaTemasParaProponerPinosARoot() throws IOException {

--- a/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
+++ b/backend/src/test/java/ar/com/kfgodel/temas/helpers/TestHelper.java
@@ -236,6 +236,7 @@ public class TestHelper {
         unTemaEnCreacionTo.setTitulo(unTitulo());
         unTemaEnCreacionTo.setDescripcion(unaDescripcion());
         unTemaEnCreacionTo.setObligatoriedad(convertirA(unaObligatoriedad(), String.class));
+        unTemaEnCreacionTo.setDuracion(DuracionDeTema.CORTO.getNombre());
         return unTemaEnCreacionTo;
     }
 


### PR DESCRIPTION
Por alguna razón no se setea el momento de creación si se convierte el TemaDeReunion creado a TemaDeReunionTo dentro de la transacción.